### PR TITLE
Support configurable worker count and log level

### DIFF
--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -19,4 +19,10 @@ properties:
     description: "Target CF API Endpoint"
   scheduler.postgres.uri:
     description: "Postgres URI (eg. postgres://user:pass@host:port/db...)"
+  scheduler.worker_count:
+    description: "Number of worker processes to run"
+    default: 20
+  scheduler.log_level:
+    description: "Log level"
+    default: "info"
 

--- a/jobs/scheduler/templates/env.erb
+++ b/jobs/scheduler/templates/env.erb
@@ -5,4 +5,7 @@ export CLIENT_ID="<%= p('scheduler.uaa.client_id') %>"
 export UAA_ENDPOINT="<%= p('scheduler.uaa.endpoint') %>"
 export DATABASE_URL="<%= p('scheduler.postgres.uri') %>"
 export CF_ENDPOINT="<%= p('scheduler.cf.api')%>"
+export workerNum="<%= p('scheduler.workers')%>"
+export LOG_LEVEL="<%= p('scheduler.log_level')%>"
+
 


### PR DESCRIPTION
- Added `scheduler.worker_count` property to specify the number of worker processes to run, defaulting to 20.
- Added `scheduler.log_level` property to set the logging level, defaulting to "info".
- Updated `env.erb` template to include environment variables for `workerNum` and `LOG_LEVEL` based on the new properties.