### PR TITLE
Upgrade to scheduler v2.0.0 with timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
 # OCF Scheduler BOSH Release
 
+A [BOSH](https://bosh.io) release for deploying the [OCF Scheduler](https://github.com/cloudfoundry-community/ocf-scheduler), which provides cron-style job and HTTP call scheduling for Cloud Foundry applications.
+
+## Jobs
+
+### `scheduler`
+
+The long-running OCF Scheduler process, managed by monit. Runs the pre-built scheduler binary from `/var/vcap/packages/scheduler/bin/scheduler`. On startup, the control script also invokes `tzlist` to initialize timezone data before launching the main process.
+
+### `smoke-tests`
+
+An errand that authenticates to Cloud Foundry, creates a temporary space, installs the OCF Scheduler CF CLI plugin, runs Go acceptance tests, and tears down the space on exit.
+
+## Architecture
+
+```mermaid
+graph TD
+    BOSH["BOSH Director"] -->|deploys| VM["Scheduler VM"]
+    VM -->|runs| Scheduler["scheduler job"]
+    Scheduler -->|connects| PG["PostgreSQL"]
+    Scheduler -->|connects| CF["CF API"]
+    Scheduler -->|authenticates via| UAA["UAA"]
+    BOSH -->|runs errand| ST["smoke-tests"]
+    ST -->|exercises scheduler via| CF
+```
+
+## Deployment
+
+### Prerequisites
+
+- A BOSH Director
+
+- A Cloud Foundry deployment with UAA
+
+- A PostgreSQL database (external or co-located)
+
+- A UAA client configured with appropriate scopes for the scheduler
+
+### Upload the Release
+
+```shell
+bosh upload-release https://github.com/cloudfoundry-community/ocf-scheduler-boshrelease/releases/download/v1.0.0/ocf-scheduler-1.0.0.tgz
+```
+
+### Properties Reference
+
+#### `scheduler` job
+
+| Property | Required | Default | Description |
+|---|---|---|---|
+| `scheduler.uaa.client_id` | Yes | | UAA client ID |
+| `scheduler.uaa.client_secret` | Yes | | UAA client secret |
+| `scheduler.uaa.endpoint` | Yes | | UAA endpoint URL |
+| `scheduler.cf.api` | Yes | | Cloud Foundry API endpoint |
+| `scheduler.postgres.uri` | Yes | | PostgreSQL connection URI (`postgres://user:pass@host:port/db`) |
+| `scheduler.workers` | No | `20` | Number of scheduling workers |
+
+#### `smoke-tests` errand
+
+| Property | Required | Description |
+|---|---|---|
+| `cf.api` | Yes | Cloud Foundry API endpoint |
+| `cf.username` | Yes | CF admin username |
+| `cf.password` | Yes | CF admin password |
+| `cf.organization` | Yes | CF organization for test space |
+| `cf.space` | Yes | CF space (a temporary sub-space is created) |
+
+### Running Smoke Tests
+
+```shell
+bosh run-errand smoke-tests
+```
+
+## Packages
+
+| Package | Contents |
+|---|---|
+| `scheduler` | Pre-built OCF Scheduler Linux binary |
+| `scheduler-cf-plugin` | Pre-built OCF Scheduler CF CLI plugin |
+| `golang-1.20-linux` | Go toolchain (used by smoke-tests at runtime) |
+| `cf-cli-8-linux` | CF CLI v8 (used by smoke-tests) |
+| `smoke-tests` | Go acceptance test source and vendored dependencies |
+
+## Development
+
+### Creating a Dev Release
+
+```shell
+bosh create-release --force
+bosh upload-release
+```
+
+### Updating Blobs
+
+The `ci/scripts/update-blob` script automates blob updates from upstream GitHub releases. It removes outdated blobs, adds the new version, and uploads to the blobstore.
+
+`config/private.yml` must contain S3 credentials for blobstore access during final release creation:
+
+```yaml
+---
+blobstore:
+  provider: s3
+  options:
+    access_key_id: YOUR_ACCESS_KEY
+    secret_access_key: YOUR_SECRET_KEY
+```
+
+## Contributing
+
+Issues and pull requests are welcome on [GitHub](https://github.com/cloudfoundry-community/ocf-scheduler-boshrelease). Please target the `develop` branch for pull requests.
+

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,7 +2,15 @@ ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.0.0-linux-amd64:
   size: 8564813
   object_id: f606f400-023d-4f79-4637-53b2619e822c
   sha: sha256:f99b37f8c3eef60ca2761d607f6d8a9adc47cbff5ca8b85ed399eb9674a5161a
+ocf-scheduler/ocf-scheduler-0.1.0-linux-amd64:
+  size: 7110656
+  object_id: e44a7d1d-eb0c-4c6a-52f7-58d3a011bd87
+  sha: sha256:fc8e5f71074176a6e00a7002c9cfb459f477445a86b13cf24a8af2f6947b810a
 ocf-scheduler/ocf-scheduler:
   size: 10768079
   object_id: ea5da087-e1a2-42b1-5d33-1be8215a4e5c
   sha: sha256:96348cd8959c980d79d4b7620cf9efc75879a5c86a96f1929c6eb2b095719321
+ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz:
+  size: 8930201
+  object_id: 25ca737c-5102-46f5-5321-c7ab87b9ac3a
+  sha: sha256:5a2d751c3b547c9a7da81e16709e5ccdcfc243f068cdccd92bcf81bb53e95cad

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,15 +2,15 @@ ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.0.0-linux-amd64:
   size: 8564813
   object_id: f606f400-023d-4f79-4637-53b2619e822c
   sha: sha256:f99b37f8c3eef60ca2761d607f6d8a9adc47cbff5ca8b85ed399eb9674a5161a
-ocf-scheduler/ocf-scheduler-0.1.0-linux-amd64:
-  size: 7110656
-  object_id: e44a7d1d-eb0c-4c6a-52f7-58d3a011bd87
-  sha: sha256:fc8e5f71074176a6e00a7002c9cfb459f477445a86b13cf24a8af2f6947b810a
 ocf-scheduler/ocf-scheduler:
   size: 10768079
   object_id: ea5da087-e1a2-42b1-5d33-1be8215a4e5c
   sha: sha256:96348cd8959c980d79d4b7620cf9efc75879a5c86a96f1929c6eb2b095719321
+ocf-scheduler/ocf-scheduler-0.1.0-linux-amd64:
+  size: 7110656
+  object_id: e44a7d1d-eb0c-4c6a-52f7-58d3a011bd87
+  sha: sha256:fc8e5f71074176a6e00a7002c9cfb459f477445a86b13cf24a8af2f6947b810a
 ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz:
-  size: 8930201
-  object_id: 25ca737c-5102-46f5-5321-c7ab87b9ac3a
-  sha: sha256:5a2d751c3b547c9a7da81e16709e5ccdcfc243f068cdccd92bcf81bb53e95cad
+  size: 8933736
+  object_id: b1d40bb1-3f88-418a-61a0-cbdd7ae0d0a2
+  sha: sha256:844446db21b138e61693f39a74ec4bdffe2d7537ccc5014473d1dc08f70e61db

--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -19,10 +19,9 @@ properties:
     description: "Target CF API Endpoint"
   scheduler.postgres.uri:
     description: "Postgres URI (eg. postgres://user:pass@host:port/db...)"
-  scheduler.worker_count:
-    description: "Number of worker processes to run"
+  scheduler.workers:
     default: 20
+    description: "Number of scheduling workers"
   scheduler.log_level:
     description: "Log level"
     default: "info"
-

--- a/jobs/scheduler/templates/bin/ctl.erb
+++ b/jobs/scheduler/templates/bin/ctl.erb
@@ -5,6 +5,7 @@ DATA_PATH=/var/vcap/data/scheduler
 STORE_PATH=/var/vcap/store/scheduler
 JOB_PATH=/var/vcap/jobs/scheduler
 SCHEDULER_PID=/var/vcap/sys/run/scheduler.pid
+TIMEZONE_PATH="${STORE_PATH}/scheduler-timezones.json"
 
 cd ${JOB_PATH}
 
@@ -14,7 +15,11 @@ case $1 in
   (start)
     echo -n "Starting Scheduler PID: $$"
     echo $$ > $SCHEDULER_PID
-    chpst -u vcap:vcap /var/vcap/packages/scheduler/bin/tzlist >> ${LOG_FILE} 2>&1 
+    [ -f "${TIMEZONE_PATH}" ] || {
+      touch "${TIMEZONE_PATH}" && chown "vcap:vcap" "${TIMEZONE_PATH}";
+    }
+
+    chpst -u vcap:vcap /var/vcap/packages/scheduler/bin/tzlist --json >> ${LOG_FILE} 2>&1 
     exec chpst -u vcap:vcap /var/vcap/packages/scheduler/bin/scheduler \
       >> ${LOG_FILE} 2>&1 
     ;;

--- a/jobs/scheduler/templates/bin/ctl.erb
+++ b/jobs/scheduler/templates/bin/ctl.erb
@@ -2,6 +2,7 @@
 
 LOG_FILE=/var/vcap/sys/log/scheduler/scheduler.log 
 DATA_PATH=/var/vcap/data/scheduler
+STORE_PATH=/var/vcap/store/scheduler
 JOB_PATH=/var/vcap/jobs/scheduler
 SCHEDULER_PID=/var/vcap/sys/run/scheduler.pid
 
@@ -13,6 +14,7 @@ case $1 in
   (start)
     echo -n "Starting Scheduler PID: $$"
     echo $$ > $SCHEDULER_PID
+    chpst -u vcap:vcap /var/vcap/packages/scheduler/bin/tzlist >> ${LOG_FILE} 2>&1 
     exec chpst -u vcap:vcap /var/vcap/packages/scheduler/bin/scheduler \
       >> ${LOG_FILE} 2>&1 
     ;;

--- a/jobs/scheduler/templates/env.erb
+++ b/jobs/scheduler/templates/env.erb
@@ -5,7 +5,6 @@ export CLIENT_ID="<%= p('scheduler.uaa.client_id') %>"
 export UAA_ENDPOINT="<%= p('scheduler.uaa.endpoint') %>"
 export DATABASE_URL="<%= p('scheduler.postgres.uri') %>"
 export CF_ENDPOINT="<%= p('scheduler.cf.api')%>"
-export WORKER_NUM="<%= p('scheduler.worker_count')%>"
+export SCHEDULER_WORKERS="<%= p('scheduler.workers')%>"
 export LOG_LEVEL="<%= p('scheduler.log_level')%>"
-
 

--- a/packages/scheduler/packaging
+++ b/packages/scheduler/packaging
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-set -ex
+set -e
 
+# ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz
+GOOS=linux
+GOARCH=amd64
+VERSION=2.0.0
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
-cp ocf-scheduler/ocf-scheduler ${BOSH_INSTALL_TARGET}/bin/scheduler
+tar -xzf ocf-scheduler/scheduler-${GOOS}-${GOARCH}-${VERSION}.tar.gz --strip-components=1 -C ${BOSH_INSTALL_TARGET}/bin \
+   ${GOOS}-${GOARCH}-${VERSION}/scheduler ${GOOS}-${GOARCH}-${VERSION}/tzlist
 
-chmod +x ${BOSH_INSTALL_TARGET}/bin/scheduler
+chmod +x ${BOSH_INSTALL_TARGET}/bin/scheduler ${BOSH_INSTALL_TARGET}/bin/tzlist
 

--- a/packages/scheduler/spec
+++ b/packages/scheduler/spec
@@ -4,4 +4,4 @@ name: scheduler
 dependencies: []
 
 files: 
-  - ocf-scheduler/ocf-scheduler
+  - ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz


### PR DESCRIPTION
## Summary
- Upgrade scheduler packaging from single binary to v2.0.0 tarball (`scheduler` + `tzlist` binaries)
- Add timezone support: `tzlist` binary generates timezone JSON, `STORE_PATH` for persistent storage, timezone file creation in `ctl.erb`
- Rename worker property from `scheduler.worker_count`/`WORKER_NUM` to `scheduler.workers`/`SCHEDULER_WORKERS`
- Re-add `scheduler.log_level`/`LOG_LEVEL` property (was unintentionally dropped during develop iteration)
- Add comprehensive README with deployment guide and properties reference

## Changes
- **`config/blobs.yml`** — 2 new blob entries (amd64 binary + v2.0.0 tarball)
- **`jobs/scheduler/spec`** — `scheduler.workers` (renamed) + `scheduler.log_level` (re-added)
- **`jobs/scheduler/templates/env.erb`** — `SCHEDULER_WORKERS` + `LOG_LEVEL` exports
- **`jobs/scheduler/templates/bin/ctl.erb`** — timezone file creation + `tzlist` execution
- **`packages/scheduler/packaging`** — tarball extraction replacing bare binary copy
- **`packages/scheduler/spec`** — updated blob reference to tarball
- **`README.md`** — new deployment guide and properties reference