### PR TITLE
Bring main up to develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ config/priv.yml
 config/private.yml
 releases/*.tgz
 dev_releases
-blobs
-.blobs
+/blobs
+/.blobs
 .idea
 .dev_builds
 .final_builds/jobs/**/*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/dev.yml
+config/priv.yml
 config/private.yml
 releases/*.tgz
 dev_releases

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ ifneq ($(FROM),)
 	  "$$(if [ -n '$(REF)' ]; then ./ci/scripts/blobs normalize '$(REF)'; \
 	      else ./ci/scripts/blobs dir-version '$(FROM)'; fi)"
 else ifneq ($(URL),)
-	@test -n "$(REF)" || { echo "URL= also needs REF= to name the version"; exit 2; }
-	./ci/scripts/blobs fetch-url $* "$(URL)" "$$(./ci/scripts/blobs normalize $(REF))"
+	./ci/scripts/blobs fetch-url $* "$(URL)"
 else
 	./ci/scripts/blobs fetch $* $(REF)
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@
 
 include blobs.mk
 
-.PHONY: help test blobs $(addprefix blobs-,$(UPSTREAMS))
+.PHONY: help test testflight-env blobs $(addprefix blobs-,$(UPSTREAMS))
 
 help:
-	@echo "make test     run the test suites"
-	@echo "make blobs    bump every upstream to its latest release"
+	@echo "make test            run the test suites"
+	@echo "make testflight-env  report director facts (read-only)"
+	@echo "make blobs           bump every upstream to its latest release"
 	@echo
 	@echo "Per-source targets:"
 	@$(foreach u,$(UPSTREAMS),echo "  make blobs-$(u)";)
@@ -25,6 +26,11 @@ test:
 	./ci/scripts/test-blobs
 	./ci/scripts/test-packaging
 	./ci/scripts/test-manifest-vars
+
+# Read-only. Reports what manifests/ocf-scheduler.yml must be written
+# against, and what testflight injects on its own.
+testflight-env:
+	./ci/scripts/testflight-env
 
 blobs: $(addprefix blobs-,$(UPSTREAMS))
 

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,11 @@ test:
 blobs: $(addprefix blobs-,$(UPSTREAMS))
 
 $(addprefix blobs-,$(UPSTREAMS)): blobs-%:
-	@test -n "$(FROM)" || { echo "FROM=<dir> required (REF/URL land in a later task)"; exit 2; }
+ifneq ($(FROM),)
 	./ci/scripts/blobs install $* "$(FROM)" "$$(./ci/scripts/blobs normalize $(REF))"
+else ifneq ($(URL),)
+	@test -n "$(REF)" || { echo "URL= also needs REF= to name the version"; exit 2; }
+	./ci/scripts/blobs fetch-url $* "$(URL)" "$$(./ci/scripts/blobs normalize $(REF))"
+else
+	./ci/scripts/blobs fetch $* $(REF)
+endif

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ blobs: $(addprefix blobs-,$(UPSTREAMS))
 
 $(addprefix blobs-,$(UPSTREAMS)): blobs-%:
 ifneq ($(FROM),)
-	./ci/scripts/blobs install $* "$(FROM)" "$$(./ci/scripts/blobs normalize $(REF))"
+	./ci/scripts/blobs install $* "$(FROM)" \
+	  "$$(if [ -n '$(REF)' ]; then ./ci/scripts/blobs normalize '$(REF)'; \
+	      else ./ci/scripts/blobs dir-version '$(FROM)'; fi)"
 else ifneq ($(URL),)
 	@test -n "$(REF)" || { echo "URL= also needs REF= to name the version"; exit 2; }
 	./ci/scripts/blobs fetch-url $* "$(URL)" "$$(./ci/scripts/blobs normalize $(REF))"

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ test:
 	./ci/scripts/test-packaging
 
 blobs: $(addprefix blobs-,$(UPSTREAMS))
+
+$(addprefix blobs-,$(UPSTREAMS)): blobs-%:
+	@test -n "$(FROM)" || { echo "FROM=<dir> required (REF/URL land in a later task)"; exit 2; }
+	./ci/scripts/blobs install $* "$(FROM)" "$$(./ci/scripts/blobs normalize $(REF))"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Makefile
+#
+# One mechanism for pinning upstream artifacts, used identically by
+# hand, by Concourse, and by GitHub Actions. All logic lives in
+# ci/scripts/blobs; these targets only pass arguments to it.
+
+include blobs.mk
+
+.PHONY: help test blobs $(addprefix blobs-,$(UPSTREAMS))
+
+help:
+	@echo "make test                       run the test suites"
+	@echo "make blobs                      bump every upstream to latest"
+	@echo "make blobs-ocf-scheduler        bump one source"
+	@echo "  REF=v2.0.1 | REF=v-2.0.1 | REF=2.0.1"
+	@echo "  URL=https://...  explicit asset"
+	@echo "  FROM=<dir>       assets already on disk"
+
+test:
+	./ci/scripts/test-blobs
+	./ci/scripts/test-packaging
+
+blobs: $(addprefix blobs-,$(UPSTREAMS))

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test:
 	./ci/scripts/test-blobs
 	./ci/scripts/test-packaging
 	./ci/scripts/test-manifest-vars
+	./ci/scripts/test-testflight-cleanup
 
 # Read-only. Reports what manifests/ocf-scheduler.yml must be written
 # against, and what testflight injects on its own.

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,17 @@ include blobs.mk
 .PHONY: help test blobs $(addprefix blobs-,$(UPSTREAMS))
 
 help:
-	@echo "make test                       run the test suites"
-	@echo "make blobs                      bump every upstream to latest"
-	@echo "make blobs-ocf-scheduler        bump one source"
-	@echo "  REF=v2.0.1 | REF=v-2.0.1 | REF=2.0.1"
-	@echo "  URL=https://...  explicit asset"
-	@echo "  FROM=<dir>       assets already on disk"
+	@echo "make test     run the test suites"
+	@echo "make blobs    bump every upstream to its latest release"
+	@echo
+	@echo "Per-source targets:"
+	@$(foreach u,$(UPSTREAMS),echo "  make blobs-$(u)";)
+	@echo
+	@echo "Modes, for a per-source target:"
+	@echo "  REF=v2.0.1     a release tag; v-2.0.1 and 2.0.1 also work"
+	@echo "  URL=https://.. one explicit asset, leaving siblings alone"
+	@echo "  FROM=<dir>     assets already on disk; reads <dir>/version"
+	@echo "  no argument    the latest release"
 
 test:
 	./ci/scripts/test-blobs

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ help:
 test:
 	./ci/scripts/test-blobs
 	./ci/scripts/test-packaging
+	./ci/scripts/test-manifest-vars
 
 blobs: $(addprefix blobs-,$(UPSTREAMS))
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,15 @@ bosh run-errand smoke-tests
 
 | Package | Contents |
 |---|---|
-| `scheduler` | Pre-built OCF Scheduler Linux binary |
-| `scheduler-cf-plugin` | Pre-built OCF Scheduler CF CLI plugin |
-| `golang-1.20-linux` | Go toolchain (used by smoke-tests at runtime) |
+| `scheduler` | Pre-built scheduler and tzlist, linux amd64 and arm64 |
+| `scheduler-cf-plugin` | CF CLI plugin: the native binary, plus every published platform under `dist/` |
+| `scheduler-crossbuilds` | Darwin scheduler builds. Referenced by no job, so carried in the release but never compiled |
+| `golang-1.22-linux` | Go toolchain (used by smoke-tests at runtime) |
 | `cf-cli-8-linux` | CF CLI v8 (used by smoke-tests) |
 | `smoke-tests` | Go acceptance test source and vendored dependencies |
+
+The architecture is selected at compile time from `uname -m`, so one
+release deploys to both amd64 and arm64 stemcells.
 
 ## Development
 
@@ -93,9 +97,32 @@ bosh upload-release
 
 ### Updating Blobs
 
-The `ci/scripts/update-blob` script automates blob updates from upstream GitHub releases. It removes outdated blobs, adds the new version, and uploads to the blobstore.
+`make blobs` pins the upstream artifacts. The same targets are used by
+hand, by Concourse, and by GitHub Actions — run `make help` for the
+full list.
 
-`config/private.yml` must contain S3 credentials for blobstore access during final release creation:
+```shell
+make blobs                                  # every source, latest release
+make blobs-ocf-scheduler REF=v2.0.1         # one source, a specific tag
+make blobs-ocf-scheduler FROM=./downloaded  # assets already on disk
+```
+
+Both upstream tag schemes resolve: `v2.0.1`, `v-2.0.1`, and a bare
+`2.0.1` all find the same release. A missing linux asset is fatal; a
+missing darwin or windows asset warns and continues.
+
+Each bump removes that source's stale blobs, adds the new ones, uploads
+them, and commits the change.
+
+### Blobstore Credentials
+
+S3 credentials reach `bosh` only through `config/private.yml`, which is
+gitignored. Two ways to supply them:
+
+- **Keep your own `config/private.yml`.** It is used as-is and never
+  modified or removed.
+- **Set `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.** A temporary
+  `config/private.yml` is generated and deleted when the run finishes.
 
 ```yaml
 ---

--- a/blobs.mk
+++ b/blobs.mk
@@ -1,0 +1,26 @@
+# blobs.mk
+#
+# Upstream artifact sources. Each source declares where it comes from,
+# which platforms are wanted, which are mandatory, and how an asset
+# filename is built from a version plus an os/arch pair.
+#
+# The two upstreams name their assets differently on purpose: the
+# scheduler ships per-platform tarballs, the plugin ships flat binaries
+# because `cf install-plugin` needs each individually downloadable.
+
+UPSTREAMS := ocf-scheduler ocf-scheduler-cf-plugin
+
+ocf-scheduler_REPO      := cloudfoundry-community/ocf-scheduler
+ocf-scheduler_BLOBDIR   := ocf-scheduler
+ocf-scheduler_PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+ocf-scheduler_REQUIRED  := linux/amd64 linux/arm64
+# $(1)=version $(2)=os $(3)=arch
+ocf-scheduler_ASSET      = ocf-scheduler-$(2)-$(3)-$(1).tar.gz
+
+ocf-scheduler-cf-plugin_REPO      := cloudfoundry-community/ocf-scheduler-cf-plugin
+ocf-scheduler-cf-plugin_BLOBDIR   := ocf-scheduler-cf-plugin
+ocf-scheduler-cf-plugin_PLATFORMS := linux/amd64 linux/arm64 \
+                                     darwin/amd64 darwin/arm64 windows/amd64
+ocf-scheduler-cf-plugin_REQUIRED  := linux/amd64 linux/arm64
+# Only the windows asset carries a .exe suffix.
+ocf-scheduler-cf-plugin_ASSET      = ocf-scheduler-cf-plugin-$(1)+$(2).$(3)$(if $(filter windows,$(2)),.exe,)

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,8 @@
 groups:
 - name: (( concat "build-" meta.pipeline "-releases" ))
   jobs:
+  # A job left out of every group is invisible in the UI once groups exist.
+  - testflight-env
   - testflight
   - rc
   - shipit
@@ -44,6 +46,32 @@ meta:
     secret:      (( param "Please set your AWS Secret Key ID" ))
 
 jobs:
+# Read-only probe. The director is only reachable from inside the test
+# environment, so the facts needed to write manifests/<source>.yml have to
+# be gathered from a worker rather than a workstation.
+- name: testflight-env
+  public: true
+  serial: true
+  plan:
+  - get: git
+  - task: testflight-env
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: registry.ops.scalecf.net/genesis-community/concourse
+      inputs:
+      - name: git
+      run:
+        path: ./git/ci/scripts/testflight-env
+        args: []
+      params:
+        BOSH_ENVIRONMENT:     (( grab meta.bosh.url ))
+        BOSH_CA_CERT:         (( grab meta.bosh.ca ))
+        BOSH_CLIENT:          (( grab meta.bosh.username ))
+        BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
+
 - name: testflight
   public: true
   serial: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -247,14 +247,17 @@ jobs:
 
 
 - name: (( grab meta.source ))
-  public: true
+  # Credentials are passed to make, so the log must not be world-readable.
+  public: false
   plan:
   - in_parallel:
     - get: git
     - get: (( grab meta.source ))
       trigger: true
       params:
-        globs: [ (( concat meta.source "-*-linux-amd64" )) ]
+        # Every platform, not just linux/amd64: the release carries darwin
+        # builds as uncompiled payload.
+        globs: [ (( concat meta.source "-*.tar.gz" )) ]
   - task: (( concat "update-" meta.source ))
     config:
       platform: linux
@@ -265,27 +268,25 @@ jobs:
       inputs:
       - name: git
       - name: (( grab meta.source ))
-      outputs:
-      - name: pushme
       run:
-        path: ./git/ci/scripts/update-blob
+        # make runs from the repo root, which is where blobs.mk and
+        # config/blobs.yml live.
+        dir: git
+        path: make
+        args:
+        - (( concat "blobs-" meta.source ))
+        # The resource has already downloaded the assets and written a
+        # version file beside them, so no ref, gh or curl is needed here.
+        - (( concat "FROM=../" meta.source ))
       params:
-        REPO_ROOT:        git
-        REPO_OUT:         pushme
-        BLOB_DIR:         (( grab meta.source ))
-        BLOB_NAME:        (( grab meta.source ))
-        BLOB_BINARY:      (( concat meta.source "-*-linux-amd64" ))
-        BLOB_DESTINATION: (( concat meta.source "/" meta.source ))
-        BLOB_CLEANUP:     (( concat meta.source "/" meta.source ))
         GIT_NAME:         (( grab meta.git.name ))
         GIT_EMAIL:        (( grab meta.git.email ))
         AWS_ACCESS_KEY:   (( grab meta.aws.access ))
         AWS_SECRET_KEY:   (( grab meta.aws.secret ))
-        BRANCH:           main
   - put: git
     params:
       rebase: true
-      repository: pushme/git
+      repository: git
 
 resources:
 - name: git
@@ -320,3 +321,7 @@ resources:
     user:         (( grab meta.github.owner ))
     repository:   (( grab meta.github.source-repo ))
     access_token: (( grab meta.github.access_token ))
+    # Upstream carries both tag schemes for the same commit: 'v2.0.1' and
+    # 'v-2.0.1'. The default filter parses neither reliably once 'v-' is
+    # in use, because 'v-2.0.1' is not semver.
+    tag_filter:   'v-?([0-9].*)'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,7 +50,9 @@ jobs:
 # environment, so the facts needed to write manifests/<source>.yml have to
 # be gathered from a worker rather than a workstation.
 - name: testflight-env
-  public: true
+  # Reports director configuration and deployment names. public: true
+  # would make that readable without authentication.
+  public: false
   serial: true
   plan:
   - get: git
@@ -73,7 +75,9 @@ jobs:
         BOSH_CLIENT_SECRET:   (( grab meta.bosh.password ))
 
 - name: testflight
-  public: true
+  # Handles deployment credentials via MANIFEST_VARS and deploys to a
+  # real director. Its logs must not be world-readable.
+  public: false
   serial: true
   plan:
   - get: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,7 @@ groups:
 - name: upstream-blobs
   jobs:
   - (( grab meta.source ))
+  - (( concat meta.source "-cf-plugin" ))
 
 meta:
   name:     (( param "Please name your pipeline" ))
@@ -288,6 +289,52 @@ jobs:
       rebase: true
       repository: git
 
+# The plugin has never had a bump job -- its blob has only ever been moved
+# by hand, which is why it sat at 1.0.0 while upstream reached 1.2.0 and
+# renamed its assets.
+- name: (( concat meta.source "-cf-plugin" ))
+  public: false
+  plan:
+  - in_parallel:
+    - get: git
+    - get: (( concat meta.source "-cf-plugin" ))
+      trigger: true
+      params:
+        # Flat per-platform binaries, not tarballs, because
+        # `cf install-plugin` needs each individually downloadable. The
+        # .sha1 sidecars are deliberately excluded.
+        globs:
+        - (( concat meta.source "-cf-plugin-*+linux.amd64" ))
+        - (( concat meta.source "-cf-plugin-*+linux.arm64" ))
+        - (( concat meta.source "-cf-plugin-*+darwin.amd64" ))
+        - (( concat meta.source "-cf-plugin-*+darwin.arm64" ))
+        - (( concat meta.source "-cf-plugin-*+windows.amd64.exe" ))
+  - task: (( concat "update-" meta.source "-cf-plugin" ))
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: registry.ops.scalecf.net/genesis-community/concourse
+      inputs:
+      - name: git
+      - name: (( concat meta.source "-cf-plugin" ))
+      run:
+        dir: git
+        path: make
+        args:
+        - (( concat "blobs-" meta.source "-cf-plugin" ))
+        - (( concat "FROM=../" meta.source "-cf-plugin" ))
+      params:
+        GIT_NAME:         (( grab meta.git.name ))
+        GIT_EMAIL:        (( grab meta.git.email ))
+        AWS_ACCESS_KEY:   (( grab meta.aws.access ))
+        AWS_SECRET_KEY:   (( grab meta.aws.secret ))
+  - put: git
+    params:
+      rebase: true
+      repository: git
+
 resources:
 - name: git
   type: git
@@ -324,4 +371,12 @@ resources:
     # Upstream carries both tag schemes for the same commit: 'v2.0.1' and
     # 'v-2.0.1'. The default filter parses neither reliably once 'v-' is
     # in use, because 'v-2.0.1' is not semver.
+    tag_filter:   'v-?([0-9].*)'
+
+- name: (( concat meta.source "-cf-plugin" ))
+  type: github-release
+  source:
+    user:         (( grab meta.github.owner ))
+    repository:   (( concat meta.source "-cf-plugin" ))
+    access_token: (( grab meta.github.access_token ))
     tag_filter:   'v-?([0-9].*)'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -92,7 +92,6 @@ jobs:
         args: []
       params:
         REPO_ROOT:            git
-        BOSH_ENV:             ((bosh
         BOSH_ENVIRONMENT:     (( grab meta.bosh.url ))
         BOSH_CA_CERT:         (( grab meta.bosh.ca ))
         BOSH_CLIENT:          (( grab meta.bosh.username ))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -269,6 +269,10 @@ jobs:
       inputs:
       - name: git
       - name: (( grab meta.source ))
+      # git is an output as well as an input. A task's changes to an input
+      # alone are discarded, so the commit would never reach the put step.
+      outputs:
+      - name: git
       run:
         # make runs from the repo root, which is where blobs.mk and
         # config/blobs.yml live.
@@ -319,6 +323,9 @@ jobs:
       inputs:
       - name: git
       - name: (( concat meta.source "-cf-plugin" ))
+      # See the scheduler job: without git as an output the commit is lost.
+      outputs:
+      - name: git
       run:
         dir: git
         path: make

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# ci/scripts/blobs
+#
+# Single mechanism for pinning upstream artifacts as BOSH blobs.
+# Invoked by the Makefile; used identically by humans and by CI.
+
+set -euo pipefail
+
+# Strip a 'v-' prefix before a plain 'v'. Reversed, the 'v' rule turns
+# 'v-2.0.1' into '-2.0.1', which downstream version parsing reads as a
+# prerelease separator and mislabels a GA release.
+normalize() {
+  local ref="${1:?normalize requires a ref}"
+  ref="${ref#v-}"
+  ref="${ref#v}"
+  echo "$ref"
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    normalize) normalize "$@" ;;
+    *) echo >&2 "usage: blobs normalize <ref>"; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -209,6 +209,32 @@ install() {  # install <source> <dir> <version>
   bosh -n upload-blobs
   drop_private_yml
   trap - EXIT
+
+  # COMMIT=no lets a caller batch several sources into one commit.
+  [[ "${COMMIT:-yes}" == "no" ]] || commit_bump "$src" "$ver"
+}
+
+# A bump that does not commit is lost: the blobs reach the blobstore but
+# config/blobs.yml never moves, so the release still references the old
+# ones and the container takes the change with it.
+commit_bump() {  # commit_bump <source> <version>
+  local src="${1:?}" ver="${2:?}"
+
+  if [[ -z "$(git status --porcelain config/blobs.yml)" ]]; then
+    echo "no blob changes to commit for ${src} ${ver}"
+    return 0
+  fi
+
+  # Only set identity if the repository has none, so a developer's own
+  # config is left alone.
+  [[ -n "$(git config user.email)" ]] || \
+    git config user.email "${GIT_EMAIL:?GIT_EMAIL required to commit}"
+  [[ -n "$(git config user.name)" ]] || \
+    git config user.name "${GIT_NAME:?GIT_NAME required to commit}"
+
+  git add config/blobs.yml
+  git commit -q -m "Bump ${src} to ${ver}"
+  echo "committed: Bump ${src} to ${ver}"
 }
 
 # URL mode's escape hatch: add exactly one asset, leaving the sibling

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -62,6 +62,30 @@ verify() {  # verify <source> <dir> <version>
   (( missing == 0 ))
 }
 
+# Both tag schemes exist upstream. Try the ref as given first, so an
+# exact tag always wins, then the two derived forms.
+resolve_tag() {  # resolve_tag <source> <ref>
+  local src="${1:?}" ref="${2:?}" repo ver candidate
+  repo=$(source_var "$src" REPO)
+  ver=$(normalize "$ref")
+
+  for candidate in "$ref" "v-${ver}" "v${ver}"; do
+    if gh release view "$candidate" --repo "$repo" >/dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  echo >&2 "no release found for '$ref' in $repo (tried: $ref v-${ver} v${ver})"
+  return 1
+}
+
+latest_tag() {  # latest_tag <source>
+  local src="${1:?}" repo
+  repo=$(source_var "$src" REPO)
+  gh release view --repo "$repo" --json tagName --jq .tagName
+}
+
 # Credentials reach bosh only through the gitignored private.yml, and
 # only for the lifetime of this function.
 write_private_yml() {
@@ -107,6 +131,37 @@ install() {  # install <source> <dir> <version>
   trap - EXIT
 }
 
+fetch() {  # fetch <source> [<ref>]
+  local src="${1:?}" ref="${2:-}" tag ver dir
+  command -v gh >/dev/null || { echo >&2 "gh is required for REF mode"; exit 2; }
+
+  if [[ -z "$ref" ]]; then
+    tag=$(latest_tag "$src")
+  else
+    tag=$(resolve_tag "$src" "$ref") || return 1
+  fi
+  ver=$(normalize "$tag")
+
+  dir=$(mktemp -d)
+  echo "fetching $src $tag into $dir"
+  gh release download "$tag" \
+    --repo "$(source_var "$src" REPO)" \
+    --dir "$dir" \
+    --pattern '*' --clobber
+
+  install "$src" "$dir" "$ver"
+  rm -rf "$dir"
+}
+
+fetch_url() {  # fetch_url <source> <url> <version>
+  local src="${1:?}" url="${2:?}" ver="${3:?}" dir
+  dir=$(mktemp -d)
+  echo "fetching $url into $dir"
+  curl -fsSL -o "$dir/$(basename "$url")" "$url"
+  install "$src" "$dir" "$ver"
+  rm -rf "$dir"
+}
+
 main() {
   local cmd="${1:-}"
   shift || true
@@ -115,6 +170,9 @@ main() {
     asset-name) asset_name "$@" ;;
     verify)     verify "$@" ;;
     install)    install "$@" ;;
+    resolve-tag) resolve_tag "$@" ;;
+    fetch)     fetch "$@" ;;
+    fetch-url) fetch_url "$@" ;;
     *) echo >&2 "usage: blobs normalize <ref>"; exit 2 ;;
   esac
 }

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -102,15 +102,37 @@ latest_tag() {  # latest_tag <source>
 # ephemeral, and only that one gets removed again.
 PRIVATE_YML_GENERATED=no
 
-write_private_yml() {
-  if [[ -f config/private.yml ]]; then
-    echo "using the existing config/private.yml"
-    PRIVATE_YML_GENERATED=no
-    return 0
-  fi
+# The same credentials Concourse resolves as ((aws.access_key_id)). Values
+# travel from safe into the file through a pipe: never as an argument, never
+# echoed, so they stay out of argv, shell history and any log.
+BLOBSTORE_VAULT_PATH="${BLOBSTORE_VAULT_PATH:-secret/concourse/cloudfoundry-community/aws}"
 
-  : "${AWS_ACCESS_KEY:?AWS_ACCESS_KEY required}"
-  : "${AWS_SECRET_KEY:?AWS_SECRET_KEY required}"
+write_from_vault() {
+  command -v safe >/dev/null || return 1
+  safe get --keys "$BLOBSTORE_VAULT_PATH" >/dev/null 2>&1 || return 1
+
+  echo "writing config/private.yml from ${BLOBSTORE_VAULT_PATH}"
+  {
+    echo "---"
+    echo "blobstore:"
+    echo "  provider: s3"
+    echo "  options:"
+    safe get "$BLOBSTORE_VAULT_PATH" \
+      | grep -E '^(access_key_id|secret_access_key):' \
+      | sed 's/^/    /'
+  } > config/private.yml
+
+  # A path that exists but holds the wrong keys yields a file with an
+  # empty options block, which bosh reports far less clearly than this.
+  grep -q 'access_key_id:' config/private.yml || {
+    rm -f config/private.yml
+    echo >&2 "${BLOBSTORE_VAULT_PATH} has no access_key_id/secret_access_key"
+    return 1
+  }
+}
+
+write_from_env() {
+  [[ -n "${AWS_ACCESS_KEY:-}" && -n "${AWS_SECRET_KEY:-}" ]] || return 1
   cat > config/private.yml <<EOF
 ---
 blobstore:
@@ -119,7 +141,25 @@ blobstore:
     access_key_id: ${AWS_ACCESS_KEY}
     secret_access_key: ${AWS_SECRET_KEY}
 EOF
-  PRIVATE_YML_GENERATED=yes
+}
+
+# Precedence: the operator's own file, then Vault, then the environment.
+write_private_yml() {
+  if [[ -f config/private.yml ]]; then
+    echo "using the existing config/private.yml"
+    PRIVATE_YML_GENERATED=no
+    return 0
+  fi
+
+  if write_from_vault || write_from_env; then
+    PRIVATE_YML_GENERATED=yes
+    return 0
+  fi
+
+  echo >&2 "no blobstore credentials: provide config/private.yml,"
+  echo >&2 "authenticate to Vault (safe auth ...), or set"
+  echo >&2 "AWS_ACCESS_KEY and AWS_SECRET_KEY"
+  return 1
 }
 
 drop_private_yml() {

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -171,6 +171,37 @@ install() {  # install <source> <dir> <version>
   trap - EXIT
 }
 
+# URL mode's escape hatch: add exactly one asset, leaving the sibling
+# platforms' blobs alone. Going through install() would first drop every
+# blob for the source, stripping a release down to whatever single file
+# the URL happened to point at.
+install_one() {  # install_one <source> <file>
+  local src="${1:?}" file="${2:?}" blobdir name
+
+  [[ -f "$file" ]] || { echo >&2 "no such asset: $file"; return 1; }
+
+  blobdir=$(source_var "$src" BLOBDIR)
+  [[ -n "${blobdir// }" ]] || {
+    echo >&2 "unknown source '$src' (no BLOBDIR declared in blobs.mk)"
+    return 1
+  }
+  name=$(basename "$file")
+
+  trap drop_private_yml EXIT
+  write_private_yml
+
+  # Replace only this exact blob, if it is already present.
+  if spruce json config/blobs.yml | jq -e \
+      --arg k "${blobdir}/${name}" 'has($k)' >/dev/null; then
+    bosh remove-blob "${blobdir}/${name}"
+  fi
+
+  bosh add-blob "$file" "${blobdir}/${name}"
+  bosh -n upload-blobs
+  drop_private_yml
+  trap - EXIT
+}
+
 fetch() {  # fetch <source> [<ref>]
   local src="${1:?}" ref="${2:-}" tag ver dir
   command -v gh >/dev/null || { echo >&2 "gh is required for REF mode"; exit 2; }
@@ -193,12 +224,12 @@ fetch() {  # fetch <source> [<ref>]
   rm -rf "$dir"
 }
 
-fetch_url() {  # fetch_url <source> <url> <version>
-  local src="${1:?}" url="${2:?}" ver="${3:?}" dir
+fetch_url() {  # fetch_url <source> <url>
+  local src="${1:?}" url="${2:?}" dir
   dir=$(mktemp -d)
   echo "fetching $url into $dir"
   curl -fsSL -o "$dir/$(basename "$url")" "$url"
-  install "$src" "$dir" "$ver"
+  install_one "$src" "$dir/$(basename "$url")"
   rm -rf "$dir"
 }
 
@@ -210,11 +241,23 @@ main() {
     asset-name)  asset_name "$@" ;;
     dir-version) dir_version "$@" ;;
     verify)      verify "$@" ;;
-    install)    install "$@" ;;
+    install)     install "$@" ;;
+    install-one) install_one "$@" ;;
     resolve-tag) resolve_tag "$@" ;;
-    fetch)     fetch "$@" ;;
-    fetch-url) fetch_url "$@" ;;
-    *) echo >&2 "usage: blobs normalize <ref>"; exit 2 ;;
+    fetch)       fetch "$@" ;;
+    fetch-url)   fetch_url "$@" ;;
+    *)
+      echo >&2 "usage: blobs <subcommand> [args]"
+      echo >&2 "  normalize <ref>                    strip a v- or v prefix"
+      echo >&2 "  asset-name <src> <ver> <os> <arch> build an asset filename"
+      echo >&2 "  dir-version <dir>                  read the version file"
+      echo >&2 "  verify <src> <dir> <ver>           check required platforms"
+      echo >&2 "  install <src> <dir> <ver>          replace a source's blobs"
+      echo >&2 "  install-one <src> <file>           add or replace one blob"
+      echo >&2 "  resolve-tag <src> <ref>            find the release tag"
+      echo >&2 "  fetch <src> [<ref>]                download a release"
+      echo >&2 "  fetch-url <src> <url>              download a single asset"
+      exit 2 ;;
   esac
 }
 

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -86,9 +86,18 @@ latest_tag() {  # latest_tag <source>
   gh release view --repo "$repo" --json tagName --jq .tagName
 }
 
-# Credentials reach bosh only through the gitignored private.yml, and
-# only for the lifetime of this function.
+# An operator may keep their own config/private.yml. That file is theirs:
+# use it as-is and never touch it. Only a file we generated ourselves is
+# ephemeral, and only that one gets removed again.
+PRIVATE_YML_GENERATED=no
+
 write_private_yml() {
+  if [[ -f config/private.yml ]]; then
+    echo "using the existing config/private.yml"
+    PRIVATE_YML_GENERATED=no
+    return 0
+  fi
+
   : "${AWS_ACCESS_KEY:?AWS_ACCESS_KEY required}"
   : "${AWS_SECRET_KEY:?AWS_SECRET_KEY required}"
   cat > config/private.yml <<EOF
@@ -99,6 +108,13 @@ blobstore:
     access_key_id: ${AWS_ACCESS_KEY}
     secret_access_key: ${AWS_SECRET_KEY}
 EOF
+  PRIVATE_YML_GENERATED=yes
+}
+
+drop_private_yml() {
+  [[ "$PRIVATE_YML_GENERATED" == "yes" ]] || return 0
+  rm -f config/private.yml
+  PRIVATE_YML_GENERATED=no
 }
 
 install() {  # install <source> <dir> <version>
@@ -108,7 +124,7 @@ install() {  # install <source> <dir> <version>
   verify "$src" "$dir" "$ver" || return 1
   blobdir=$(source_var "$src" BLOBDIR)
 
-  trap 'rm -f config/private.yml' EXIT
+  trap drop_private_yml EXIT
   write_private_yml
 
   # Drop every existing blob under this source's directory, so a bump
@@ -127,7 +143,7 @@ install() {  # install <source> <dir> <version>
   done
 
   bosh -n upload-blobs
-  rm -f config/private.yml
+  drop_private_yml
   trap - EXIT
 }
 

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -40,9 +40,20 @@ EOF
 # Required platforms must be present; the rest warn and continue.
 verify() {  # verify <source> <dir> <version>
   local src="${1:?}" dir="${2:?}" ver="${3:?}"
-  local missing=0 plat os arch name
+  local missing=0 plat os arch name required platforms
 
-  for plat in $(source_var "$src" REQUIRED); do
+  required=$(source_var "$src" REQUIRED)
+  platforms=$(source_var "$src" PLATFORMS)
+
+  # An unknown source, a missing blobs.mk, or the wrong working directory
+  # all expand to empty lists. Both loops below would then run zero times
+  # and report success, turning a real failure into a silent no-op.
+  if [[ -z "${required// }" || -z "${platforms// }" ]]; then
+    echo >&2 "unknown source '$src' (no platforms declared in blobs.mk)"
+    return 1
+  fi
+
+  for plat in $required; do
     os=${plat%%/*}; arch=${plat##*/}
     name=$(asset_name "$src" "$ver" "$os" "$arch")
     if [[ ! -f "$dir/$name" ]]; then
@@ -51,8 +62,8 @@ verify() {  # verify <source> <dir> <version>
     fi
   done
 
-  for plat in $(source_var "$src" PLATFORMS); do
-    case " $(source_var "$src" REQUIRED) " in *" $plat "*) continue ;; esac
+  for plat in $platforms; do
+    case " $required " in *" $plat "*) continue ;; esac
     os=${plat%%/*}; arch=${plat##*/}
     name=$(asset_name "$src" "$ver" "$os" "$arch")
     [[ -f "$dir/$name" ]] || \

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -17,11 +17,104 @@ normalize() {
   echo "$ref"
 }
 
+# Read a per-source variable out of blobs.mk without duplicating the
+# table here. Make is the single source of truth for it.
+source_var() {  # source_var <source> <suffix>
+  local src="${1:?}" suffix="${2:?}"
+  make --no-print-directory -f - <<EOF
+include blobs.mk
+show:
+	@echo \$(${src}_${suffix})
+EOF
+}
+
+asset_name() {  # asset_name <source> <version> <os> <arch>
+  local src="${1:?}" ver="${2:?}" os="${3:?}" arch="${4:?}"
+  make --no-print-directory -f - <<EOF
+include blobs.mk
+show:
+	@echo \$(call ${src}_ASSET,${ver},${os},${arch})
+EOF
+}
+
+# Required platforms must be present; the rest warn and continue.
+verify() {  # verify <source> <dir> <version>
+  local src="${1:?}" dir="${2:?}" ver="${3:?}"
+  local missing=0 plat os arch name
+
+  for plat in $(source_var "$src" REQUIRED); do
+    os=${plat%%/*}; arch=${plat##*/}
+    name=$(asset_name "$src" "$ver" "$os" "$arch")
+    if [[ ! -f "$dir/$name" ]]; then
+      echo >&2 "missing required asset: $src $ver $plat ($name)"
+      missing=$((missing + 1))
+    fi
+  done
+
+  for plat in $(source_var "$src" PLATFORMS); do
+    case " $(source_var "$src" REQUIRED) " in *" $plat "*) continue ;; esac
+    os=${plat%%/*}; arch=${plat##*/}
+    name=$(asset_name "$src" "$ver" "$os" "$arch")
+    [[ -f "$dir/$name" ]] || \
+      echo >&2 "warning: $src $ver has no $plat asset ($name) - continuing"
+  done
+
+  (( missing == 0 ))
+}
+
+# Credentials reach bosh only through the gitignored private.yml, and
+# only for the lifetime of this function.
+write_private_yml() {
+  : "${AWS_ACCESS_KEY:?AWS_ACCESS_KEY required}"
+  : "${AWS_SECRET_KEY:?AWS_SECRET_KEY required}"
+  cat > config/private.yml <<EOF
+---
+blobstore:
+  provider: s3
+  options:
+    access_key_id: ${AWS_ACCESS_KEY}
+    secret_access_key: ${AWS_SECRET_KEY}
+EOF
+}
+
+install() {  # install <source> <dir> <version>
+  local src="${1:?}" dir="${2:?}" ver="${3:?}"
+  local blobdir plat os arch name stale
+
+  verify "$src" "$dir" "$ver" || return 1
+  blobdir=$(source_var "$src" BLOBDIR)
+
+  trap 'rm -f config/private.yml' EXIT
+  write_private_yml
+
+  # Drop every existing blob under this source's directory, so a bump
+  # never leaves two versions for one platform behind.
+  stale=$(spruce json config/blobs.yml | jq -r \
+    --arg d "${blobdir}/" 'keys[] | select(startswith($d))')
+  if [[ -n "$stale" ]]; then
+    echo "$stale" | xargs -L1 bosh remove-blob
+  fi
+
+  for plat in $(source_var "$src" PLATFORMS); do
+    os=${plat%%/*}; arch=${plat##*/}
+    name=$(asset_name "$src" "$ver" "$os" "$arch")
+    [[ -f "$dir/$name" ]] || continue
+    bosh add-blob "$dir/$name" "${blobdir}/${name}"
+  done
+
+  bosh -n upload-blobs
+  rm -f config/private.yml
+  trap - EXIT
+}
+
 main() {
   local cmd="${1:-}"
   shift || true
   case "$cmd" in
-    normalize) normalize "$@" ;;
+    normalize)  normalize "$@" ;;
+    asset-name) asset_name "$@" ;;
+    verify)     verify "$@" ;;
+    install)    install "$@" ;;
     *) echo >&2 "usage: blobs normalize <ref>"; exit 2 ;;
   esac
 }

--- a/ci/scripts/blobs
+++ b/ci/scripts/blobs
@@ -128,6 +128,19 @@ drop_private_yml() {
   PRIVATE_YML_GENERATED=no
 }
 
+# The version Concourse's github-release resource records beside the
+# assets it downloaded. This is what keeps FROM mode dependency-free:
+# the pipeline hands over a directory and nothing else.
+dir_version() {  # dir_version <dir>
+  local dir="${1:?dir_version requires a directory}"
+  if [[ -f "$dir/version" ]]; then
+    normalize "$(tr -d '[:space:]' < "$dir/version")"
+    return 0
+  fi
+  echo >&2 "no version file in $dir - pass REF= to name the version"
+  return 1
+}
+
 install() {  # install <source> <dir> <version>
   local src="${1:?}" dir="${2:?}" ver="${3:?}"
   local blobdir plat os arch name stale
@@ -193,9 +206,10 @@ main() {
   local cmd="${1:-}"
   shift || true
   case "$cmd" in
-    normalize)  normalize "$@" ;;
-    asset-name) asset_name "$@" ;;
-    verify)     verify "$@" ;;
+    normalize)   normalize "$@" ;;
+    asset-name)  asset_name "$@" ;;
+    dir-version) dir_version "$@" ;;
+    verify)      verify "$@" ;;
     install)    install "$@" ;;
     resolve-tag) resolve_tag "$@" ;;
     fetch)     fetch "$@" ;;

--- a/ci/scripts/manifest-vars
+++ b/ci/scripts/manifest-vars
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# ci/scripts/manifest-vars
+#
+# Normalises the MANIFEST_VARS pipeline parameter on stdin into the vars
+# file testflight passes to `bosh int --vars-file`.
+#
+# Vars may be written either way:
+#
+#   cf_api=https://api.example.com
+#   cf_api: https://api.example.com
+#
+# Only a leading `identifier =` is rewritten. An earlier global
+# substitution rewrote every '=' on the line, so a value carrying its own
+# '=' was silently corrupted -- a Postgres URI became
+# 'postgres://h/db?sslmode: disable', and a base64 value lost its padding.
+
+set -euo pipefail
+
+sed -e 's/^\([[:space:]]*\)\([A-Za-z_][A-Za-z0-9_-]*\)[[:space:]]*=[[:space:]]*/\1\2: /'

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -58,6 +58,15 @@ check "missing darwin warns only" "0" \
   "$("$BLOBS" verify ocf-scheduler "$scratch/in" 2.0.1 >/dev/null 2>&1; echo $?)"
 rm -rf "$scratch"
 
+# An unknown source expands to empty REQUIRED/PLATFORMS lists. Both loops
+# would then run zero times and report success, so a genuinely missing
+# asset would pass. Empty must be fatal.
+scratch=$(mktemp -d)
+mkdir -p "$scratch/in"
+check_fails "unknown source is fatal" \
+  "$BLOBS" verify no-such-source "$scratch/in" 2.0.1
+rm -rf "$scratch"
+
 # --- install ---------------------------------------------------------------
 #
 # Runs offline: a stub `bosh` on PATH records calls instead of reaching S3.

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -107,6 +107,49 @@ check "pre-existing private.yml unmodified" "operator-owned" \
   "$(cat "$box/config/private.yml" 2>/dev/null)"
 rm -rf "$box"
 
+# With no file and no env vars, credentials come from Vault via safe.
+# The stub stands in for an authenticated safe; the values are fake.
+stub_safe() {  # stub_safe <dir>
+  cat > "$1/stub/safe" <<'EOF'
+#!/bin/sh
+# safe get --keys <path>   -> key names
+# safe get <path>          -> key: value YAML
+if [ "$2" = "--keys" ]; then
+  echo "access_key_id"; echo "secret_access_key"; exit 0
+fi
+echo "--- # $2"
+echo "access_key_id: FAKE-ACCESS-KEY"
+echo "secret_access_key: FAKE-SECRET-KEY"
+EOF
+  chmod +x "$1/stub/safe"
+}
+
+box=$(mk_sandbox)
+stub_safe "$box"
+seed_scheduler_assets "$box/in" 2.0.1
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    BLOBSTORE_VAULT_PATH=secret/fake/aws \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) > "$box/log" 2>&1
+check "vault used when no file or env" "yes" \
+  "$(grep -q 'config/private.yml from secret/fake/aws' "$box/log" && echo yes || echo no)"
+check "generated from vault is removed" "no" \
+  "$([[ -f "$box/config/private.yml" ]] && echo yes || echo no)"
+check "vault credentials never printed" "0" \
+  "$(grep -c 'FAKE-SECRET-KEY' "$box/log" 2>/dev/null || true)"
+rm -rf "$box"
+
+# An operator's own file still wins over Vault.
+box=$(mk_sandbox)
+stub_safe "$box"
+seed_scheduler_assets "$box/in" 2.0.1
+printf 'operator-owned\n' > "$box/config/private.yml"
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    BLOBSTORE_VAULT_PATH=secret/fake/aws \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) >/dev/null 2>&1
+check "existing file beats vault" "operator-owned" \
+  "$(cat "$box/config/private.yml" 2>/dev/null)"
+rm -rf "$box"
+
 # One we created ourselves is ephemeral and must be cleaned up.
 box=$(mk_sandbox)
 seed_scheduler_assets "$box/in" 2.0.1

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -119,6 +119,15 @@ check "all four assets added" "4" \
   "$(grep -c '^add-blob' "$box/calls" 2>/dev/null || true)"
 rm -rf "$box"
 
+# Concourse's github-release resource writes a `version` file beside the
+# assets. FROM mode must read it rather than demanding a REF.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+echo "2.0.1" > "$box/in/version"
+check "version derived from FROM dir" "2.0.1" \
+  "$(cd "$box" && "$BLOBS" dir-version "$box/in")"
+rm -rf "$box"
+
 echo
 if (( fails > 0 )); then
   echo "${fails} failure(s)"

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -128,6 +128,20 @@ check "version derived from FROM dir" "2.0.1" \
   "$(cd "$box" && "$BLOBS" dir-version "$box/in")"
 rm -rf "$box"
 
+# URL mode is a single-asset escape hatch. It must replace only that
+# asset's blob, never wipe the sibling platforms the way install() does.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    AWS_ACCESS_KEY=k AWS_SECRET_KEY=s \
+    "$BLOBS" install-one ocf-scheduler \
+      "$box/in/ocf-scheduler-linux-amd64-2.0.1.tar.gz" ) >/dev/null 2>&1
+check "single asset added" "1" \
+  "$(grep -c '^add-blob' "$box/calls" 2>/dev/null || true)"
+check "siblings not removed" "0" \
+  "$(grep -c '^remove-blob' "$box/calls" 2>/dev/null || true)"
+rm -rf "$box"
+
 echo
 if (( fails > 0 )); then
   echo "${fails} failure(s)"

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -78,12 +78,21 @@ mk_sandbox() {  # mk_sandbox -> prints sandbox dir
   mkdir -p "$d/config" "$d/stub" "$d/in"
   echo '{}' > "$d/config/blobs.yml"
   : > "$d/calls"
+  # The stub mutates config/blobs.yml on add-blob the way bosh does, so
+  # the commit path has something to see.
   cat > "$d/stub/bosh" <<'EOF'
 #!/bin/sh
 echo "$@" >> "${BOSH_CALL_LOG:?}"
+if [ "$1" = "add-blob" ]; then
+  printf '%s:\n  size: 1\n' "$3" >> config/blobs.yml
+fi
 exit 0
 EOF
   chmod +x "$d/stub/bosh"
+  ( cd "$d" \
+    && git init -q . \
+    && git add blobs.mk config/blobs.yml \
+    && git -c user.name=t -c user.email=t@t commit -q -m "seed" )
   echo "$d"
 }
 
@@ -160,6 +169,32 @@ check "generated private.yml removed" "no" \
   "$([[ -f "$box/config/private.yml" ]] && echo yes || echo no)"
 check "all four assets added" "4" \
   "$(grep -c '^add-blob' "$box/calls" 2>/dev/null || true)"
+rm -rf "$box"
+
+# A bump has to commit its own result. Without this the blobs reach the
+# blobstore but config/blobs.yml never moves, so the release still
+# references the old ones and the change is lost with the container.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    AWS_ACCESS_KEY=k AWS_SECRET_KEY=s GIT_NAME=ci GIT_EMAIL=ci@example.com \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) >/dev/null 2>&1
+check "the bump is committed" "Bump ocf-scheduler to 2.0.1" \
+  "$(cd "$box" && git log -1 --format='%s' 2>/dev/null)"
+check "nothing left uncommitted" "" \
+  "$(cd "$box" && git status --porcelain config/blobs.yml)"
+check "commit subject within 48 chars" "yes" \
+  "$(cd "$box" && [ "$(git log -1 --format='%s' | wc -c)" -le 49 ] && echo yes || echo no)"
+rm -rf "$box"
+
+# COMMIT=no lets a caller batch several bumps into one commit.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    AWS_ACCESS_KEY=k AWS_SECRET_KEY=s COMMIT=no \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) >/dev/null 2>&1
+check "COMMIT=no leaves it staged only" "seed" \
+  "$(cd "$box" && git log -1 --format='%s' 2>/dev/null)"
 rm -rf "$box"
 
 # Concourse's github-release resource writes a `version` file beside the

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# ci/scripts/test-blobs
+#
+# Tests for ci/scripts/blobs helper subcommands.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLOBS="${HERE}/blobs"
+fails=0
+
+check() {  # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1: expected '$2', got '$3'"
+    fails=$((fails + 1))
+  fi
+}
+
+# Ref normalization. 'v-' must be stripped before 'v'; reversed, the 'v'
+# rule leaves a leading '-' on a v- tag.
+check "bare version unchanged"  "2.0.1" "$("$BLOBS" normalize 2.0.1)"
+check "v prefix stripped"       "2.0.1" "$("$BLOBS" normalize v2.0.1)"
+check "v- prefix stripped"      "2.0.1" "$("$BLOBS" normalize v-2.0.1)"
+check "prerelease preserved"    "2.0.1-rc.1" "$("$BLOBS" normalize v2.0.1-rc.1)"
+check "v- with prerelease"      "2.0.1-rc.1" "$("$BLOBS" normalize v-2.0.1-rc.1)"
+
+echo
+if (( fails > 0 )); then
+  echo "${fails} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -19,6 +19,15 @@ check() {  # check <description> <expected> <actual>
   fi
 }
 
+check_fails() {  # check_fails <description> <command...>
+  if "${@:2}" >/dev/null 2>&1; then
+    echo "FAIL - $1: expected non-zero exit, got 0"
+    fails=$((fails + 1))
+  else
+    echo "ok   - $1"
+  fi
+}
+
 # Ref normalization. 'v-' must be stripped before 'v'; reversed, the 'v'
 # rule leaves a leading '-' on a v- tag.
 check "bare version unchanged"  "2.0.1" "$("$BLOBS" normalize 2.0.1)"
@@ -26,6 +35,28 @@ check "v prefix stripped"       "2.0.1" "$("$BLOBS" normalize v2.0.1)"
 check "v- prefix stripped"      "2.0.1" "$("$BLOBS" normalize v-2.0.1)"
 check "prerelease preserved"    "2.0.1-rc.1" "$("$BLOBS" normalize v2.0.1-rc.1)"
 check "v- with prerelease"      "2.0.1-rc.1" "$("$BLOBS" normalize v-2.0.1-rc.1)"
+
+# Asset-name construction must match upstream exactly.
+check "scheduler asset name" \
+  "ocf-scheduler-linux-amd64-2.0.1.tar.gz" \
+  "$("$BLOBS" asset-name ocf-scheduler 2.0.1 linux amd64)"
+check "plugin asset name" \
+  "ocf-scheduler-cf-plugin-1.2.0+linux.amd64" \
+  "$("$BLOBS" asset-name ocf-scheduler-cf-plugin 1.2.0 linux amd64)"
+check "plugin windows asset name" \
+  "ocf-scheduler-cf-plugin-1.2.0+windows.amd64.exe" \
+  "$("$BLOBS" asset-name ocf-scheduler-cf-plugin 1.2.0 windows amd64)"
+
+# A missing linux asset is fatal; a missing darwin asset warns.
+scratch=$(mktemp -d)
+mkdir -p "$scratch/in"
+: > "$scratch/in/ocf-scheduler-linux-amd64-2.0.1.tar.gz"
+check_fails "missing required linux/arm64 is fatal" \
+  "$BLOBS" verify ocf-scheduler "$scratch/in" 2.0.1
+: > "$scratch/in/ocf-scheduler-linux-arm64-2.0.1.tar.gz"
+check "missing darwin warns only" "0" \
+  "$("$BLOBS" verify ocf-scheduler "$scratch/in" 2.0.1 >/dev/null 2>&1; echo $?)"
+rm -rf "$scratch"
 
 echo
 if (( fails > 0 )); then

--- a/ci/scripts/test-blobs
+++ b/ci/scripts/test-blobs
@@ -58,6 +58,58 @@ check "missing darwin warns only" "0" \
   "$("$BLOBS" verify ocf-scheduler "$scratch/in" 2.0.1 >/dev/null 2>&1; echo $?)"
 rm -rf "$scratch"
 
+# --- install ---------------------------------------------------------------
+#
+# Runs offline: a stub `bosh` on PATH records calls instead of reaching S3.
+# spruce and jq are the real ones.
+
+mk_sandbox() {  # mk_sandbox -> prints sandbox dir
+  local d; d=$(mktemp -d)
+  cp "${HERE}/../../blobs.mk" "$d/blobs.mk"
+  mkdir -p "$d/config" "$d/stub" "$d/in"
+  echo '{}' > "$d/config/blobs.yml"
+  : > "$d/calls"
+  cat > "$d/stub/bosh" <<'EOF'
+#!/bin/sh
+echo "$@" >> "${BOSH_CALL_LOG:?}"
+exit 0
+EOF
+  chmod +x "$d/stub/bosh"
+  echo "$d"
+}
+
+seed_scheduler_assets() {  # seed_scheduler_assets <dir> <version>
+  local d=$1 v=$2 p
+  for p in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+    : > "$d/ocf-scheduler-$p-$v.tar.gz"
+  done
+}
+
+# A pre-existing private.yml is the operator's own credentials file. It
+# must be used as-is and must survive, including when the run fails.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+printf 'operator-owned\n' > "$box/config/private.yml"
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) >/dev/null 2>&1
+check "pre-existing private.yml survives" "yes" \
+  "$([[ -f "$box/config/private.yml" ]] && echo yes || echo no)"
+check "pre-existing private.yml unmodified" "operator-owned" \
+  "$(cat "$box/config/private.yml" 2>/dev/null)"
+rm -rf "$box"
+
+# One we created ourselves is ephemeral and must be cleaned up.
+box=$(mk_sandbox)
+seed_scheduler_assets "$box/in" 2.0.1
+( cd "$box" && PATH="$box/stub:$PATH" BOSH_CALL_LOG="$box/calls" \
+    AWS_ACCESS_KEY=k AWS_SECRET_KEY=s \
+    "$BLOBS" install ocf-scheduler "$box/in" 2.0.1 ) >/dev/null 2>&1
+check "generated private.yml removed" "no" \
+  "$([[ -f "$box/config/private.yml" ]] && echo yes || echo no)"
+check "all four assets added" "4" \
+  "$(grep -c '^add-blob' "$box/calls" 2>/dev/null || true)"
+rm -rf "$box"
+
 echo
 if (( fails > 0 )); then
   echo "${fails} failure(s)"

--- a/ci/scripts/test-manifest-vars
+++ b/ci/scripts/test-manifest-vars
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# ci/scripts/test-manifest-vars
+#
+# Tests for ci/scripts/manifest-vars, the filter that normalises the
+# MANIFEST_VARS parameter into the vars file testflight hands to bosh.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${HERE}/manifest-vars"
+fails=0
+
+check() {  # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1"
+    echo "       expected: $2"
+    echo "       actual:   $3"
+    fails=$((fails + 1))
+  fi
+}
+
+filter() { printf '%s\n' "$1" | "$FILTER"; }
+
+# The historical purpose: accept key=value as well as key: value.
+check "key=value becomes yaml" \
+  "cf_api: https://api.example.com" \
+  "$(filter 'cf_api=https://api.example.com')"
+
+check "spaces around = are absorbed" \
+  "cf_api: https://api.example.com" \
+  "$(filter 'cf_api = https://api.example.com')"
+
+check "yaml passes through untouched" \
+  "cf_api: https://api.example.com" \
+  "$(filter 'cf_api: https://api.example.com')"
+
+# The bug this filter exists to fix. A global s/=/:/ rewrote every '='
+# in the value, so a URI query string or a padded token was corrupted.
+check "only the first = is converted" \
+  "postgres_uri: postgres://u:p@h:5432/sched?sslmode=disable" \
+  "$(filter 'postgres_uri=postgres://u:p@h:5432/sched?sslmode=disable')"
+
+check "= inside an already-yaml value survives" \
+  "postgres_uri: postgres://u:p@h:5432/sched?sslmode=disable" \
+  "$(filter 'postgres_uri: postgres://u:p@h:5432/sched?sslmode=disable')"
+
+check "base64 padding survives" \
+  "token: YWJjZGVm==" \
+  "$(filter 'token=YWJjZGVm==')"
+
+check "multiple query params survive" \
+  "uri: postgres://h/db?sslmode=disable&pool_max_conns=10" \
+  "$(filter 'uri=postgres://h/db?sslmode=disable&pool_max_conns=10')"
+
+# The current pipeline default must keep working.
+check "empty document passes through" \
+  "--- {}" \
+  "$(filter '--- {}')"
+
+# Whatever comes out has to be parseable, since testflight feeds it to
+# bosh int as a vars file.
+out=$(printf 'cf_api=https://api.example.com\npg=postgres://h/db?sslmode=disable\n' | "$FILTER")
+check "output is valid yaml" "0" \
+  "$(printf '%s\n' "$out" | spruce json >/dev/null 2>&1; echo $?)"
+
+echo
+if (( fails > 0 )); then
+  echo "${fails} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/ci/scripts/test-packaging
+++ b/ci/scripts/test-packaging
@@ -94,6 +94,22 @@ test_scheduler_ambiguous() {
 }
 test_scheduler_ambiguous
 
+# With no match at all, bash leaves the glob pattern literal, so a naive
+# count reports 1. The message must say zero, not "found 1".
+test_scheduler_missing() {
+  local work install out
+  work=$(mktemp -d); install=$(mktemp -d)
+  mkdir -p "$work/ocf-scheduler"
+  stub_uname x86_64 "$work"
+  out=$( cd "$work" \
+         && PATH="$work/stub:$PATH" BOSH_INSTALL_TARGET="$install" \
+            bash "$HERE/packages/scheduler/packaging" 2>&1 )
+  check "missing blob reports zero" "yes" \
+        "$(printf '%s' "$out" | grep -q 'found 0' && echo yes || echo no)"
+  rm -rf "$work" "$install"
+}
+test_scheduler_missing
+
 # --- scheduler-cf-plugin package -------------------------------------------
 
 mk_plugin_binaries() {  # mk_plugin_binaries <version> <destdir>

--- a/ci/scripts/test-packaging
+++ b/ci/scripts/test-packaging
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# ci/scripts/test-packaging
+#
+# Runs each package's packaging script against fabricated blobs and
+# asserts on the installed output. Packaging scripts run on a stemcell
+# with cwd set to the extracted blob root, so each case reproduces that.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fails=0
+
+check() {  # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1: expected '$2', got '$3'"
+    fails=$((fails + 1))
+  fi
+}
+
+check_fails() {  # check_fails <description> <command...>
+  if "${@:2}" >/dev/null 2>&1; then
+    echo "FAIL - $1: expected non-zero exit, got 0"
+    fails=$((fails + 1))
+  else
+    echo "ok   - $1"
+  fi
+}
+
+# Put a fake `uname` earlier in PATH so both architectures are testable
+# from any host.
+stub_uname() {  # stub_uname <machine> <dir>
+  mkdir -p "$2/stub"
+  cat > "$2/stub/uname" <<EOF
+#!/bin/sh
+if [ "\$1" = "-m" ]; then echo "$1"; else exec /usr/bin/uname "\$@"; fi
+EOF
+  chmod +x "$2/stub/uname"
+}
+
+# Build a tarball matching the upstream scheduler layout:
+#   <os>-<arch>-<version>/{scheduler,tzlist} plus .sha1/.sha256 sidecars
+mk_scheduler_tarball() {  # mk_scheduler_tarball <os> <arch> <version> <destdir>
+  local os=$1 arch=$2 ver=$3 dest=$4 d
+  d=$(mktemp -d)
+  mkdir -p "$d/$os-$arch-$ver"
+  printf '#!/bin/sh\necho scheduler\n' > "$d/$os-$arch-$ver/scheduler"
+  printf '#!/bin/sh\necho tzlist\n'    > "$d/$os-$arch-$ver/tzlist"
+  : > "$d/$os-$arch-$ver/scheduler.sha1"
+  : > "$d/$os-$arch-$ver/scheduler.sha256"
+  : > "$d/$os-$arch-$ver/tzlist.sha1"
+  : > "$d/$os-$arch-$ver/tzlist.sha256"
+  mkdir -p "$dest"
+  (cd "$d" && tar -czf "$dest/ocf-scheduler-$os-$arch-$ver.tar.gz" "$os-$arch-$ver")
+  rm -rf "$d"
+}
+
+# --- scheduler package -----------------------------------------------------
+
+test_scheduler() {  # test_scheduler <machine> <arch> <version>
+  local machine=$1 arch=$2 ver=$3
+  local work install
+  work=$(mktemp -d); install=$(mktemp -d)
+  mk_scheduler_tarball linux "$arch" "$ver" "$work/ocf-scheduler"
+  stub_uname "$machine" "$work"
+  ( cd "$work" \
+    && PATH="$work/stub:$PATH" BOSH_INSTALL_TARGET="$install" \
+       bash "$HERE/packages/scheduler/packaging" >/dev/null )
+  check "scheduler installed ($machine)"  "yes" \
+        "$([[ -x "$install/bin/scheduler" ]] && echo yes || echo no)"
+  check "tzlist installed ($machine)"     "yes" \
+        "$([[ -x "$install/bin/tzlist" ]] && echo yes || echo no)"
+  check "no sha sidecars ($machine)"      "0" \
+        "$(find "$install" -name '*.sha*' | wc -l | tr -d ' ')"
+  rm -rf "$work" "$install"
+}
+
+test_scheduler x86_64  amd64 2.0.1
+test_scheduler aarch64 arm64 2.0.1
+
+# Two blobs for one arch must be rejected, not silently resolved.
+test_scheduler_ambiguous() {
+  local work install
+  work=$(mktemp -d); install=$(mktemp -d)
+  mk_scheduler_tarball linux amd64 2.0.1 "$work/ocf-scheduler"
+  mk_scheduler_tarball linux amd64 2.0.2 "$work/ocf-scheduler"
+  stub_uname x86_64 "$work"
+  check_fails "ambiguous blobs rejected" \
+    env -C "$work" PATH="$work/stub:$PATH" BOSH_INSTALL_TARGET="$install" \
+      bash "$HERE/packages/scheduler/packaging"
+  rm -rf "$work" "$install"
+}
+test_scheduler_ambiguous
+
+echo
+if (( fails > 0 )); then
+  echo "${fails} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/ci/scripts/test-packaging
+++ b/ci/scripts/test-packaging
@@ -94,6 +94,43 @@ test_scheduler_ambiguous() {
 }
 test_scheduler_ambiguous
 
+# --- scheduler-cf-plugin package -------------------------------------------
+
+mk_plugin_binaries() {  # mk_plugin_binaries <version> <destdir>
+  local ver=$1 dest=$2
+  mkdir -p "$dest"
+  local p
+  for p in linux.amd64 linux.arm64 darwin.amd64 darwin.arm64; do
+    printf '#!/bin/sh\necho plugin\n' > "$dest/ocf-scheduler-cf-plugin-$ver+$p"
+    : > "$dest/ocf-scheduler-cf-plugin-$ver+$p.sha1"
+  done
+  printf 'MZ\n' > "$dest/ocf-scheduler-cf-plugin-$ver+windows.amd64.exe"
+  : > "$dest/ocf-scheduler-cf-plugin-$ver+windows.amd64.sha1"
+}
+
+test_plugin() {  # test_plugin <machine> <arch> <version>
+  local machine=$1 arch=$2 ver=$3
+  local work install
+  work=$(mktemp -d); install=$(mktemp -d)
+  mk_plugin_binaries "$ver" "$work/ocf-scheduler-cf-plugin"
+  stub_uname "$machine" "$work"
+  ( cd "$work" \
+    && PATH="$work/stub:$PATH" BOSH_INSTALL_TARGET="$install" \
+       bash "$HERE/packages/scheduler-cf-plugin/packaging" >/dev/null )
+  check "plugin binary installed ($machine)" "yes" \
+        "$([[ -x "$install/bin/scheduler-cf-plugin" ]] && echo yes || echo no)"
+  check "all platforms served ($machine)"    "5" \
+        "$(find "$install/dist" -type f ! -name '*.sha1' | wc -l | tr -d ' ')"
+  check "no sha1 sidecars served ($machine)" "0" \
+        "$(find "$install/dist" -name '*.sha1' | wc -l | tr -d ' ')"
+  check "windows exe served ($machine)"      "1" \
+        "$(find "$install/dist" -name '*+windows.amd64.exe' | wc -l | tr -d ' ')"
+  rm -rf "$work" "$install"
+}
+
+test_plugin x86_64  amd64 1.2.0
+test_plugin aarch64 arm64 1.2.0
+
 echo
 if (( fails > 0 )); then
   echo "${fails} failure(s)"

--- a/ci/scripts/test-packaging
+++ b/ci/scripts/test-packaging
@@ -110,6 +110,26 @@ test_scheduler_missing() {
 }
 test_scheduler_missing
 
+# --- scheduler-crossbuilds package -----------------------------------------
+
+# Carried payload. No job references it, so it is never compiled on a
+# stemcell, but it must still install correctly if one ever does.
+test_crossbuilds() {
+  local work install
+  work=$(mktemp -d); install=$(mktemp -d)
+  mk_scheduler_tarball darwin amd64 2.0.1 "$work/ocf-scheduler"
+  mk_scheduler_tarball darwin arm64 2.0.1 "$work/ocf-scheduler"
+  mk_scheduler_tarball linux  amd64 2.0.1 "$work/ocf-scheduler"
+  ( cd "$work" && BOSH_INSTALL_TARGET="$install" \
+      bash "$HERE/packages/scheduler-crossbuilds/packaging" >/dev/null )
+  check "both darwin builds carried" "2" \
+        "$(find "$install/dist" -name 'ocf-scheduler-darwin-*' | wc -l | tr -d ' ')"
+  check "linux build not carried" "0" \
+        "$(find "$install/dist" -name 'ocf-scheduler-linux-*' | wc -l | tr -d ' ')"
+  rm -rf "$work" "$install"
+}
+test_crossbuilds
+
 # --- scheduler-cf-plugin package -------------------------------------------
 
 mk_plugin_binaries() {  # mk_plugin_binaries <version> <destdir>

--- a/ci/scripts/test-testflight-cleanup
+++ b/ci/scripts/test-testflight-cleanup
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# ci/scripts/test-testflight-cleanup
+#
+# The EXIT trap runs last, and in bash a trap's return status becomes the
+# script's. Left alone, that lets `bosh delete-deployment` failing turn a
+# passing testflight into a failed job, and lets it overwrite the exit
+# code of a real failure. These tests pin the status through both paths.
+#
+# Runs offline: a stub bosh on PATH stands in for a director.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTFLIGHT="${HERE}/testflight"
+fails=0
+
+check() {  # check <description> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1: expected '$2', got '$3'"
+    fails=$((fails + 1))
+  fi
+}
+
+# Run testflight against a throwaway repo with no manifest, so it exits 1
+# at the manifest check and the trap fires. <bosh_rc> is what the stub
+# bosh returns, standing in for the cleanup outcome.
+run_testflight() {  # run_testflight <bosh_rc> -> prints exit status
+  local bosh_rc=$1 d
+  d=$(mktemp -d)
+  ( cd "$d" && git init -q . )
+  mkdir -p "$d/stub"
+  cat > "$d/stub/bosh" <<EOF
+#!/bin/sh
+echo "Succeeded"
+exit ${bosh_rc}
+EOF
+  chmod +x "$d/stub/bosh"
+
+  (
+    cd "$d"
+    PATH="$d/stub:$PATH" \
+    CLEANUP_DELAY=0 \
+    REPO_ROOT="$d" \
+    BOSH_ENVIRONMENT=https://director.invalid:25555 \
+    BOSH_CA_CERT=fake \
+    BOSH_CLIENT=admin \
+    BOSH_CLIENT_SECRET=fake \
+    BOSH_DEPLOYMENT=test-ci \
+    MANIFEST_PATH=manifests/absent.yml \
+    AWS_ACCESS_KEY=fake \
+    AWS_SECRET_KEY=fake \
+      bash "$TESTFLIGHT" >/dev/null 2>&1
+    echo $?
+  )
+  rm -rf "$d"
+}
+
+# A real failure must survive cleanup, whatever cleanup does.
+check "failure preserved when cleanup succeeds" "1" "$(run_testflight 0)"
+check "failure preserved when cleanup fails"    "1" "$(run_testflight 3)"
+
+echo
+if (( fails > 0 )); then
+  echo "${fails} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/ci/scripts/test-testflight-cleanup
+++ b/ci/scripts/test-testflight-cleanup
@@ -52,15 +52,23 @@ EOF
     MANIFEST_PATH=manifests/absent.yml \
     AWS_ACCESS_KEY=fake \
     AWS_SECRET_KEY=fake \
-      bash "$TESTFLIGHT" >/dev/null 2>&1
+      bash "$TESTFLIGHT" > "$d/out" 2>&1
     echo $?
   )
+  cp "$d/out" "${LAST_OUTPUT:-/dev/null}" 2>/dev/null || true
   rm -rf "$d"
 }
 
 # A real failure must survive cleanup, whatever cleanup does.
+LAST_OUTPUT=$(mktemp)
 check "failure preserved when cleanup succeeds" "1" "$(run_testflight 0)"
-check "failure preserved when cleanup fails"    "1" "$(run_testflight 3)"
+check "cleanup success is announced" "yes" \
+  "$(grep -q 'deployment cleanup ok' "$LAST_OUTPUT" && echo yes || echo no)"
+
+check "failure preserved when cleanup fails" "1" "$(run_testflight 3)"
+check "cleanup failure is announced" "yes" \
+  "$(grep -q 'warning: deployment cleanup failed' "$LAST_OUTPUT" && echo yes || echo no)"
+rm -f "$LAST_OUTPUT"
 
 echo
 if (( fails > 0 )); then

--- a/ci/scripts/test-testflight-cleanup
+++ b/ci/scripts/test-testflight-cleanup
@@ -65,6 +65,16 @@ check "failure preserved when cleanup succeeds" "1" "$(run_testflight 0)"
 check "cleanup success is announced" "yes" \
   "$(grep -q 'deployment cleanup ok' "$LAST_OUTPUT" && echo yes || echo no)"
 
+# The cause must be restated at the end. Cleanup output otherwise leaves
+# two success messages as the last thing before Concourse says 'failed'.
+check "failure is restated last" "yes" \
+  "$(grep -q 'testflight FAILED (rc=1)' "$LAST_OUTPUT" && echo yes || echo no)"
+check "the cause is named" "yes" \
+  "$(grep -q 'cause: deployment manifest .* does not exist' "$LAST_OUTPUT" \
+     && echo yes || echo no)"
+check "failure banner is the last output" "yes" \
+  "$(tail -1 "$LAST_OUTPUT" | grep -q '^#\+$' && echo yes || echo no)"
+
 check "failure preserved when cleanup fails" "1" "$(run_testflight 3)"
 check "cleanup failure is announced" "yes" \
   "$(grep -q 'warning: deployment cleanup failed' "$LAST_OUTPUT" && echo yes || echo no)"

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -47,6 +47,17 @@ cleanup() {
 	else
 		echo >&2 "warning: deployment cleanup failed (rc=$?)"
 	fi
+
+	# Cleanup runs after the failure that caused it, and its own output
+	# ends in success messages. Without this the last thing before
+	# Concourse prints 'failed' claims everything worked, and the real
+	# cause sits above a banner and four blank lines, off screen.
+	if (( rc != 0 )); then
+		echo >&2 "###############################################"
+		echo >&2 "testflight FAILED (rc=${rc})"
+		echo >&2 "cause: ${FAILURE:-see the first error above the cleanup section}"
+		echo >&2 "###############################################"
+	fi
 	exit $rc
 }
 trap cleanup EXIT SIGINT SIGTERM
@@ -60,7 +71,8 @@ header "Confirming testflight inputs"
 
 echo "Confirming deployment manifest ${MANIFEST_PATH} exists"
 if [[ ! -f ${MANIFEST_PATH} ]]; then
-	echo "Deployment manifest ${MANIFEST_PATH} does not exist"
+	echo >&2 "Deployment manifest ${MANIFEST_PATH} does not exist"
+	FAILURE="deployment manifest ${MANIFEST_PATH} does not exist"
 	exit 1
 fi
 

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -83,8 +83,12 @@ mkdir -p tmp
 # and will be converted to "key: value" YAML
 echo "${MANIFEST_VARS:-"{} ---"}" | $DIR/manifest-vars > tmp/vars.yml
 if [[ ! -z $DEBUG ]]; then
-	echo "Variables passed to deployment manifest:"
-	cat tmp/vars.yml
+	# Names only. These vars carry deployment credentials, and every job
+	# in this pipeline is public, so build logs are readable without
+	# authentication -- printing the values would publish them.
+	echo "Variables passed to deployment manifest (names only):"
+	grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_-]*:' tmp/vars.yml \
+	  | tr -d ' :' | sed 's/^/  /'
 fi
 # convert YAML to JSON to check YAML validity
 spruce json tmp/vars.yml > /dev/null

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -31,7 +31,19 @@ delete_deployment() {
 	header "Cleaning up deployment..."
 	bosh -n delete-deployment --force
 }
-trap "echo; echo; echo; sleep 10; delete_deployment" EXIT SIGINT SIGTERM
+
+# The EXIT trap runs last, and in bash a trap's return status becomes the
+# script's. Without capturing $? first, a failed cleanup would fail an
+# otherwise passing run, and would overwrite the exit code of a real
+# failure. Cleanup problems are worth reporting, not worth failing on.
+cleanup() {
+	local rc=$?
+	echo; echo; echo
+	sleep "${CLEANUP_DELAY:-10}"
+	delete_deployment || echo >&2 "warning: deployment cleanup failed (rc=$?)"
+	exit $rc
+}
+trap cleanup EXIT SIGINT SIGTERM
 
 
 cd ${REPO_ROOT:?required}

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -40,7 +40,13 @@ cleanup() {
 	local rc=$?
 	echo; echo; echo
 	sleep "${CLEANUP_DELAY:-10}"
-	delete_deployment || echo >&2 "warning: deployment cleanup failed (rc=$?)"
+	# State the outcome either way. A silent success is indistinguishable
+	# from this fix not being deployed at all.
+	if delete_deployment; then
+		echo "deployment cleanup ok"
+	else
+		echo >&2 "warning: deployment cleanup failed (rc=$?)"
+	fi
 	exit $rc
 }
 trap cleanup EXIT SIGINT SIGTERM

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -51,7 +51,7 @@ mkdir -p tmp
 
 # $MANIFEST_VARS can either be "key: value" or "key=value"
 # and will be converted to "key: value" YAML
-echo "${MANIFEST_VARS:-"{} ---"}" | sed -e "s/ *= */: /g" > tmp/vars.yml
+echo "${MANIFEST_VARS:-"{} ---"}" | $DIR/manifest-vars > tmp/vars.yml
 if [[ ! -z $DEBUG ]]; then
 	echo "Variables passed to deployment manifest:"
 	cat tmp/vars.yml

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -176,7 +176,10 @@ for op_patch_file in ${MANIFEST_OP_PATHS//,/ } ; do
    op_patch_files_flags="${op_patch_files_flags} -o $op_patch_file"
 done
 
-set -x
+# Tracing stays off unless asked for. It traces every command for the
+# rest of the run, including the deploy and any errands, so a future
+# command expanding a credential would print it to a public build log.
+[[ -z $DEBUG ]] || set -x
 
 bosh int <( spruce merge "${MANIFEST_PATH}" ) \
   -o tmp/deployment.yml    \

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -88,13 +88,10 @@ for dep in $(bosh deployments --column=name 2>/dev/null | tr -d '[:blank:]'); do
     echo "    bosh -d ${dep} manifest | grep -m1 system_domain"
   fi
 
-  # Credential NAMES only -- never values. This is how to find the CF
-  # admin password and any UAA client secrets without Vault access; the
-  # director's credential store already holds them.
-  echo
-  echo "  credentials this deployment owns (names only):"
-  bosh -d "$dep" variables 2>/dev/null | sed 's/^/    /' \
-    || echo "    could not list variables for ${dep}"
+  # Deliberately not listing this deployment's credential names. Even
+  # names describe internal structure, and every job in this pipeline is
+  # public, so a build log needs no authentication to read. Run
+  # `bosh -d <deployment> variables` by hand if the list is needed.
 done
 
 if [[ "$found" == "no" ]]; then

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -22,7 +22,7 @@ trap 'rm -f "$cc"' EXIT
 bosh cloud-config > "$cc"
 
 names() {  # names <top-level key>
-  spruce json "$cc" | jq -r "(.$1 // [])[].name" | paste -sd' ' -
+  spruce json "$cc" | jq -r "(.$1 // [])[].name" | tr '\n' ' '
 }
 
 header "cloud-config offers"
@@ -38,7 +38,8 @@ kv vm_type   "$(bosh int "$cc" --path /vm_types/0/name)"
 kv disk_type "$(bosh int "$cc" --path /disk_types/0/name)"
 kv network   "$(bosh int "$cc" --path /networks/0/name)"
 
-if [[ -n "$(names azs)" ]]; then
+azs=$(names azs)
+if [[ -n "${azs// }" ]]; then
   echo
   echo "  NOTE: azs are defined. testflight does NOT inject them, so"
   echo "        manifests/ocf-scheduler.yml must declare azs: itself."

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -48,6 +48,11 @@ else
   echo "  NOTE: no azs defined, so the manifest can omit azs:."
 fi
 
+# The manifest has to name a stemcell os that is actually uploaded here,
+# and testflight does not inject one.
+header "uploaded stemcells"
+bosh stemcells
+
 header "deployments"
 bosh deployments
 

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -56,18 +56,23 @@ bosh deployments
 header "cf api endpoint"
 found=no
 for dep in $(bosh deployments --column=name 2>/dev/null | tr -d '[:blank:]'); do
-  releases=$(bosh -d "$dep" manifest 2>/dev/null \
-             | spruce json 2>/dev/null \
-             | jq -r '(.releases // [])[].name' 2>/dev/null || true)
+  [[ -n "$dep" ]] || continue
+  manifest=$(bosh -d "$dep" manifest 2>/dev/null | spruce json 2>/dev/null || true)
+  [[ -n "$manifest" ]] || continue
+
+  # Flatten to a space-separated list. Left as newlines, the patterns
+  # below cannot match -- they look for a space on either side.
+  releases=$(printf '%s' "$manifest" \
+             | jq -r '(.releases // [])[].name' 2>/dev/null | tr '\n' ' ' || true)
   case " $releases " in
-    *" cf "*|*" capi "*|*" routing "*) ;;
+    *" cf "*|*" capi "*|*" routing "*|*" uaa "*) ;;
     *) continue ;;
   esac
   found=yes
-  domain=$(bosh -d "$dep" manifest 2>/dev/null \
-           | spruce json 2>/dev/null \
-           | jq -r '.. | .system_domain? // empty' 2>/dev/null \
-           | head -1 || true)
+  domain=$(printf '%s' "$manifest" \
+           | jq -r '[.. | objects | select(has("system_domain")) | .system_domain]
+                    | map(select(type == "string")) | first // empty' \
+             2>/dev/null || true)
   kv deployment "$dep"
   if [[ -n "$domain" ]]; then
     kv system_domain "$domain"

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# ci/scripts/testflight-env
+#
+# Reports the director facts that manifests/ocf-scheduler.yml has to be
+# written against: which azs, vm_types, disk_types and networks the
+# cloud-config offers, which of those testflight will inject on its own,
+# and whether a Cloud Foundry is deployed for the scheduler to talk to.
+#
+# Read-only -- it deploys nothing and changes nothing. Needs
+# BOSH_ENVIRONMENT plus the usual BOSH_* credentials, same as testflight.
+
+set -euo pipefail
+
+: "${BOSH_ENVIRONMENT:?required}"
+
+header() { echo; echo "=== $* ==="; }
+kv() { printf '  %-12s %s\n' "$1" "$2"; }
+
+cc=$(mktemp)
+trap 'rm -f "$cc"' EXIT
+bosh cloud-config > "$cc"
+
+names() {  # names <top-level key>
+  spruce json "$cc" | jq -r "(.$1 // [])[].name" | paste -sd' ' -
+}
+
+header "cloud-config offers"
+kv azs        "$(names azs)"
+kv vm_types   "$(names vm_types)"
+kv disk_types "$(names disk_types)"
+kv networks   "$(names networks)"
+
+# Mirrors ci/scripts/testflight:97-99 exactly, so what prints here is
+# what the generated op file will substitute into every instance group.
+header "testflight will inject"
+kv vm_type   "$(bosh int "$cc" --path /vm_types/0/name)"
+kv disk_type "$(bosh int "$cc" --path /disk_types/0/name)"
+kv network   "$(bosh int "$cc" --path /networks/0/name)"
+
+if [[ -n "$(names azs)" ]]; then
+  echo
+  echo "  NOTE: azs are defined. testflight does NOT inject them, so"
+  echo "        manifests/ocf-scheduler.yml must declare azs: itself."
+else
+  echo
+  echo "  NOTE: no azs defined, so the manifest can omit azs:."
+fi
+
+header "deployments"
+bosh deployments
+
+# The scheduler needs a CF API endpoint and a CF UAA. Neither can come
+# from this director's own uaa, which issues BOSH tokens.
+header "cf api endpoint"
+found=no
+for dep in $(bosh deployments --column=name 2>/dev/null | tr -d '[:blank:]'); do
+  releases=$(bosh -d "$dep" manifest 2>/dev/null \
+             | spruce json 2>/dev/null \
+             | jq -r '(.releases // [])[].name' 2>/dev/null || true)
+  case " $releases " in
+    *" cf "*|*" capi "*|*" routing "*) ;;
+    *) continue ;;
+  esac
+  found=yes
+  domain=$(bosh -d "$dep" manifest 2>/dev/null \
+           | spruce json 2>/dev/null \
+           | jq -r '.. | .system_domain? // empty' 2>/dev/null \
+           | head -1 || true)
+  kv deployment "$dep"
+  if [[ -n "$domain" ]]; then
+    kv system_domain "$domain"
+    kv cf.api        "https://api.${domain}"
+    kv uaa.endpoint  "https://uaa.${domain}"
+  else
+    echo "  system_domain not found in the manifest; check it by hand:"
+    echo "    bosh -d ${dep} manifest | grep -m1 system_domain"
+  fi
+done
+
+if [[ "$found" == "no" ]]; then
+  echo "  No deployment carrying a cf/capi/routing release was found."
+  echo "  The scheduler cannot be given a working cf.api or uaa.endpoint"
+  echo "  until one exists."
+fi
+
+header "still needed by hand"
+cat <<'EOS'
+  scheduler.postgres.uri          no postgres job ships in this release
+  scheduler.uaa.client_id         a UAA client on the CF above
+  scheduler.uaa.client_secret     the same client's secret
+
+  Once known, set them as MANIFEST_VARS in ci/pipeline.yml. Values may
+  be written key=value or "key: value"; a value carrying its own '='
+  (a postgres query string) is now preserved.
+EOS

--- a/ci/scripts/testflight-env
+++ b/ci/scripts/testflight-env
@@ -87,6 +87,14 @@ for dep in $(bosh deployments --column=name 2>/dev/null | tr -d '[:blank:]'); do
     echo "  system_domain not found in the manifest; check it by hand:"
     echo "    bosh -d ${dep} manifest | grep -m1 system_domain"
   fi
+
+  # Credential NAMES only -- never values. This is how to find the CF
+  # admin password and any UAA client secrets without Vault access; the
+  # director's credential store already holds them.
+  echo
+  echo "  credentials this deployment owns (names only):"
+  bosh -d "$dep" variables 2>/dev/null | sed 's/^/    /' \
+    || echo "    could not list variables for ${dep}"
 done
 
 if [[ "$found" == "no" ]]; then

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,23 @@
-ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.0.0-linux-amd64:
-  size: 8564813
-  object_id: f606f400-023d-4f79-4637-53b2619e822c
-  sha: sha256:f99b37f8c3eef60ca2761d607f6d8a9adc47cbff5ca8b85ed399eb9674a5161a
+ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.2.0+darwin.amd64:
+  size: 14615776
+  object_id: 6f128fc6-847e-4ac1-43b7-f05ecfebeb8f
+  sha: sha256:a766c81e158a798e8ed9e15a81357cd3859dc80f24420fee8c741954aa95917e
+ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.2.0+darwin.arm64:
+  size: 13941378
+  object_id: 24b33aa5-899c-43ea-451d-e12a106cbc4b
+  sha: sha256:ee5f161f11148299723bc43602a696d21914e38a0497b75386b8eb94f785efc8
+ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.2.0+linux.amd64:
+  size: 14608419
+  object_id: 69a4ba31-9b7e-4b94-56c4-d8082b0c9023
+  sha: sha256:609f9e4db0b0f60ffa391635fce467bc59fa18c63875bc9eb657b23fb36fec89
+ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.2.0+linux.arm64:
+  size: 13891624
+  object_id: 3685a34b-acbd-447d-7da8-2e3d6b7296ae
+  sha: sha256:fa438cc70a39683aec0d484f7b88aecf8560c2562efd9407db92ff98000eee91
+ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.2.0+windows.amd64.exe:
+  size: 14958080
+  object_id: 329c08c2-ddd9-4aee-77b4-0a4fb9cf16dd
+  sha: sha256:783ee1983c8f8c6ad08a96f40d1bd535b1773b8c5a51a65d0f3880b74659b030
 ocf-scheduler/ocf-scheduler-darwin-amd64-2.0.1.tar.gz:
   size: 9685424
   object_id: 9b3acefe-6490-4b5c-5341-e5fe7cb33c90

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,15 +2,19 @@ ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-1.0.0-linux-amd64:
   size: 8564813
   object_id: f606f400-023d-4f79-4637-53b2619e822c
   sha: sha256:f99b37f8c3eef60ca2761d607f6d8a9adc47cbff5ca8b85ed399eb9674a5161a
-ocf-scheduler/ocf-scheduler:
-  size: 10768079
-  object_id: ea5da087-e1a2-42b1-5d33-1be8215a4e5c
-  sha: sha256:96348cd8959c980d79d4b7620cf9efc75879a5c86a96f1929c6eb2b095719321
-ocf-scheduler/ocf-scheduler-0.1.0-linux-amd64:
-  size: 7110656
-  object_id: e44a7d1d-eb0c-4c6a-52f7-58d3a011bd87
-  sha: sha256:fc8e5f71074176a6e00a7002c9cfb459f477445a86b13cf24a8af2f6947b810a
-ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz:
-  size: 8933736
-  object_id: b1d40bb1-3f88-418a-61a0-cbdd7ae0d0a2
-  sha: sha256:844446db21b138e61693f39a74ec4bdffe2d7537ccc5014473d1dc08f70e61db
+ocf-scheduler/ocf-scheduler-darwin-amd64-2.0.1.tar.gz:
+  size: 9685424
+  object_id: 9b3acefe-6490-4b5c-5341-e5fe7cb33c90
+  sha: sha256:5e7c0fe6019e4d0b6201c189fe2440597240cfb06da6843cee75044515ba32db
+ocf-scheduler/ocf-scheduler-darwin-arm64-2.0.1.tar.gz:
+  size: 9167056
+  object_id: 13ef96bf-3363-4156-5d68-24d691ab9890
+  sha: sha256:a22fecfc263f3937d734d344fa5d762fb28ea88f326452798d3b5841f7af0d85
+ocf-scheduler/ocf-scheduler-linux-amd64-2.0.1.tar.gz:
+  size: 9539690
+  object_id: e385c01f-7103-41f4-5735-04d5c1b5b5fc
+  sha: sha256:cd08039989bce0ee2d7a3d1d37b02681c7554c26edfc8e2af7b6452a3d7aac8e
+ocf-scheduler/ocf-scheduler-linux-arm64-2.0.1.tar.gz:
+  size: 8739062
+  object_id: 9c656268-02a6-4974-51f6-5e4b99b5088b
+  sha: sha256:db0d98de389614bbf2e737edd85f1932199ff36a4f0d8d2978169cdbabcf7610

--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -7,6 +7,7 @@ templates:
 
 packages:
 - scheduler
+- scheduler-cf-plugin
 
 properties: 
   scheduler.uaa.client_id:

--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -23,5 +23,5 @@ properties:
     default: 20
     description: "Number of scheduling workers"
   scheduler.log_level:
-    description: "Log level"
+    description: "Log level trace, debug, info, warn, error, fatal, panic"
     default: "info"

--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -1,5 +1,6 @@
 ---
 name: smoke-tests
+lifecycle: errand
 
 templates:
   run: bin/run

--- a/manifests/ocf-scheduler.yml
+++ b/manifests/ocf-scheduler.yml
@@ -1,0 +1,85 @@
+---
+# manifests/ocf-scheduler.yml
+#
+# Deployment manifest for ci/scripts/testflight. Restored from
+# manifests/scheduler.yml, which existed for two days in May 2022
+# (525a024, deleted by e1d80f1) and was never replaced -- the pipeline
+# added in 2023 has looked for this filename ever since and never found
+# it.
+#
+# testflight generates an ops file and overwrites several values here, so
+# do not bother tuning them:
+#
+#   /name                             <- $BOSH_DEPLOYMENT
+#   /releases/name=ocf-scheduler      <- the dev release it just built
+#   /instance_groups/*/vm_type        <- a vm_type from the cloud-config
+#   /instance_groups/*/networks       <- a network from the cloud-config
+#   /instance_groups/*/persistent_disk_type
+#                                     <- only for groups declaring one
+#
+# It does NOT inject `azs` or the stemcell, so both are declared here and
+# have to match the target director.
+
+name: ocf-scheduler
+
+# The version is replaced with the dev release under test. The entry must
+# exist for the ops file's `path: /releases/name=ocf-scheduler` to resolve.
+releases:
+- name: ocf-scheduler
+  version: latest
+
+# ubuntu-jammy is the only stemcell uploaded to thunderdome (verified
+# 2026-07-29: bosh-vsphere-esxi-ubuntu-jammy-go_agent/1.1298, the sole
+# entry). Revisit when noble is available there.
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 5000-60000
+  update_watch_time: 5000-60000
+
+instance_groups:
+- name: ocf-scheduler
+  azs: [z1]
+  instances: 1
+  stemcell: default
+  vm_type: default
+  networks:
+  - name: default
+  jobs:
+  - name: scheduler
+    release: ocf-scheduler
+    properties:
+      scheduler:
+        cf:
+          api: ((cf_api))
+        uaa:
+          endpoint: ((uaa_endpoint))
+          client_id: ((uaa_client_id))
+          client_secret: ((uaa_client_secret))
+        postgres:
+          uri: ((postgres_uri))
+
+# lifecycle belongs on the instance group, which is where BOSH reads it.
+- name: smoke-tests
+  azs: [z1]
+  lifecycle: errand
+  instances: 1
+  stemcell: default
+  vm_type: default
+  networks:
+  - name: default
+  jobs:
+  - name: smoke-tests
+    release: ocf-scheduler
+    properties:
+      cf:
+        api: ((cf_api))
+        username: ((cf_username))
+        password: ((cf_password))
+        organization: ((cf_organization))
+        space: ((cf_space))

--- a/packages/scheduler-cf-plugin/packaging
+++ b/packages/scheduler-cf-plugin/packaging
@@ -10,7 +10,10 @@ esac
 
 # Role 1: the native binary, executed by the smoke-tests errand.
 set -- ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+linux.${arch}
-if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+# An unmatched glob is left literal by the shell, so count only the
+# entries that are real files. Otherwise zero blobs reports as one.
+[ -f "$1" ] || set --
+if [ $# -ne 1 ]; then
   echo >&2 "expected exactly one linux/${arch} plugin blob, found $#"
   exit 1
 fi

--- a/packages/scheduler-cf-plugin/packaging
+++ b/packages/scheduler-cf-plugin/packaging
@@ -1,9 +1,29 @@
 #!/bin/bash
 
-set -ex
+set -eu
 
-mkdir -p ${BOSH_INSTALL_TARGET}/bin
+case "$(uname -m)" in
+  x86_64)        arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo >&2 "unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
 
-cp ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/scheduler-cf-plugin
+# Role 1: the native binary, executed by the smoke-tests errand.
+set -- ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+linux.${arch}
+if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+  echo >&2 "expected exactly one linux/${arch} plugin blob, found $#"
+  exit 1
+fi
 
-chmod +x ${BOSH_INSTALL_TARGET}/bin/scheduler-cf-plugin
+mkdir -p "${BOSH_INSTALL_TARGET}/bin"
+cp "$1" "${BOSH_INSTALL_TARGET}/bin/scheduler-cf-plugin"
+chmod +x "${BOSH_INSTALL_TARGET}/bin/scheduler-cf-plugin"
+
+# Role 2: every platform, kept under its published name so that
+# {os}.{arch} stays parseable by whatever serves these.
+mkdir -p "${BOSH_INSTALL_TARGET}/dist"
+for binary in ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*; do
+  [ -f "$binary" ] || continue
+  case "$binary" in *.sha1|*.sha256) continue ;; esac
+  cp "$binary" "${BOSH_INSTALL_TARGET}/dist/"
+done

--- a/packages/scheduler-cf-plugin/spec
+++ b/packages/scheduler-cf-plugin/spec
@@ -1,5 +1,11 @@
 ---
 name: scheduler-cf-plugin
 
+dependencies: []
+
 files:
-- ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*-linux-amd64
+  - ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+linux.amd64
+  - ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+linux.arm64
+  - ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+darwin.amd64
+  - ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+darwin.arm64
+  - ocf-scheduler-cf-plugin/ocf-scheduler-cf-plugin-*+windows.amd64.exe

--- a/packages/scheduler-crossbuilds/packaging
+++ b/packages/scheduler-crossbuilds/packaging
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+# Carried payload, not a deploy target: these binaries are for testing
+# non-linux paths and are never executed on a stemcell. No job depends
+# on this package, so BOSH ships it without compiling it.
+
+mkdir -p "${BOSH_INSTALL_TARGET}/dist"
+
+found=0
+for tarball in ocf-scheduler/ocf-scheduler-darwin-*.tar.gz; do
+  [ -f "$tarball" ] || continue
+  cp "$tarball" "${BOSH_INSTALL_TARGET}/dist/"
+  found=$((found + 1))
+done
+
+echo "carried ${found} non-stemcell scheduler build(s)"

--- a/packages/scheduler-crossbuilds/spec
+++ b/packages/scheduler-crossbuilds/spec
@@ -3,6 +3,11 @@ name: scheduler-crossbuilds
 
 dependencies: []
 
+# Builds for platforms no stemcell provides. Carried in the release
+# tarball, never compiled, because no job depends on this package.
 files:
   - ocf-scheduler/ocf-scheduler-darwin-amd64-*.tar.gz
   - ocf-scheduler/ocf-scheduler-darwin-arm64-*.tar.gz
+  # Uncomment once upstream restores the windows target:
+  # cloudfoundry-community/ocf-scheduler#26
+  # - ocf-scheduler/ocf-scheduler-windows-amd64-*.tar.gz

--- a/packages/scheduler-crossbuilds/spec
+++ b/packages/scheduler-crossbuilds/spec
@@ -1,0 +1,8 @@
+---
+name: scheduler-crossbuilds
+
+dependencies: []
+
+files:
+  - ocf-scheduler/ocf-scheduler-darwin-amd64-*.tar.gz
+  - ocf-scheduler/ocf-scheduler-darwin-arm64-*.tar.gz

--- a/packages/scheduler/packaging
+++ b/packages/scheduler/packaging
@@ -1,16 +1,31 @@
 #!/bin/bash
 
-set -e
+set -eu
 
-# ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz
-GOOS=linux
-GOARCH=amd64
-VERSION=2.0.0
+case "$(uname -m)" in
+  x86_64)        arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo >&2 "unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
 
-mkdir -p ${BOSH_INSTALL_TARGET}/bin
+# Exactly one blob per architecture. A stale blob left by a failed bump
+# would otherwise glob two tarballs and silently pick one.
+set -- ocf-scheduler/ocf-scheduler-linux-${arch}-*.tar.gz
+if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+  echo >&2 "expected exactly one linux/${arch} blob, found $#"
+  exit 1
+fi
 
-tar -xzf ocf-scheduler/scheduler-${GOOS}-${GOARCH}-${VERSION}.tar.gz --strip-components=1 -C ${BOSH_INSTALL_TARGET}/bin \
-   ${GOOS}-${GOARCH}-${VERSION}/scheduler ${GOOS}-${GOARCH}-${VERSION}/tzlist
+# The tarball's inner directory carries the version, and is derivable
+# from the filename: ocf-scheduler-linux-amd64-2.0.1.tar.gz
+#                 ->              linux-amd64-2.0.1/
+inner=$(basename "$1" .tar.gz)
+inner=${inner#ocf-scheduler-}
 
-chmod +x ${BOSH_INSTALL_TARGET}/bin/scheduler ${BOSH_INSTALL_TARGET}/bin/tzlist
+mkdir -p "${BOSH_INSTALL_TARGET}/bin"
 
+tar -xzf "$1" --strip-components=1 -C "${BOSH_INSTALL_TARGET}/bin" \
+    "${inner}/scheduler" "${inner}/tzlist"
+
+chmod +x "${BOSH_INSTALL_TARGET}/bin/scheduler" \
+         "${BOSH_INSTALL_TARGET}/bin/tzlist"

--- a/packages/scheduler/packaging
+++ b/packages/scheduler/packaging
@@ -11,7 +11,10 @@ esac
 # Exactly one blob per architecture. A stale blob left by a failed bump
 # would otherwise glob two tarballs and silently pick one.
 set -- ocf-scheduler/ocf-scheduler-linux-${arch}-*.tar.gz
-if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+# An unmatched glob is left literal by the shell, so count only the
+# entries that are real files. Otherwise zero blobs reports as one.
+[ -f "$1" ] || set --
+if [ $# -ne 1 ]; then
   echo >&2 "expected exactly one linux/${arch} blob, found $#"
   exit 1
 fi

--- a/packages/scheduler/spec
+++ b/packages/scheduler/spec
@@ -3,5 +3,6 @@ name: scheduler
 
 dependencies: []
 
-files: 
-  - ocf-scheduler/scheduler-linux-amd64-2.0.0.tar.gz
+files:
+  - ocf-scheduler/ocf-scheduler-linux-amd64-*.tar.gz
+  - ocf-scheduler/ocf-scheduler-linux-arm64-*.tar.gz


### PR DESCRIPTION
Promotes the blob mechanism (PR #6, 43 commits) from `develop` to `main`.

## Why this is needed now

`main` is the branch the release path actually targets, and it currently knows nothing about the blob mechanism:

- `ci/settings.yml:35` sets the pipeline's git resource to `branch: main`, so any repipe points CI at a branch with no `blobs.mk` and breaks every job. The deployed pipeline is only working today because its resource still points at the now-merged `feature/blob-mechanism`.
- `ci/pipeline.yml:194` runs `shipit` with `BRANCH: main`, and `ci/scripts/shipit:111` does `git merge --no-edit ${BRANCH}`.

So until `main` catches up, the release path merges in a branch that predates the mechanism it needs.

## Content

No unique content exists on `main`. The only commit it has that `develop` lacks is `802f0e2`, the merge commit from PR #5, whose changes are already in `develop` — the merge base is `cc549a3`. The diff is therefore exactly PR #6's: 23 files, 1510 insertions, 61 deletions.

## Merge type

Please merge with a **merge commit**, not a squash. A squash would leave `main` with a tree matching `develop` but no shared ancestry, pinning the merge base at `cc549a3`; the next `develop` → `main` merge would then try to re-apply all 43 commits onto a `main` that already has them. A merge commit advances the merge base and keeps subsequent promotions clean. PR #5 was merged the same way.

## Still open after this

Testflight remains blocked at `bosh int --var-errs` on nine unset `MANIFEST_VARS` (the pipeline passes `--- {}`), so `rc` stays unreachable and `shipit` cannot be triggered. That is deployment-environment work, unaffected by this promotion.