### PR TITLE
Add a shipit-manual job and correct the release notes

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,7 @@ groups:
   - testflight
   - rc
   - shipit
+  - shipit-manual
 - name: versioning
   jobs:
   - major
@@ -210,6 +211,68 @@ jobs:
       tag:    gh/tag
       body:   gh/notes.md
       globs: [gh/artifacts/*]
+  - put: version-bump-patch
+    resource: version
+    params:
+      bump: patch
+
+# Same as shipit, minus the testflight -> rc gate. testflight cannot pass in
+# this environment (its manifest needs a Postgres URI and a UAA client the test
+# environment does not provide), and a final release can only be cut where the
+# blobstore credentials resolve -- which is here, not on a workstation.
+- name: shipit-manual
+  public: false
+  serial: true
+  plan:
+  - in_parallel:
+    - get: version
+      params:
+        bump: final
+    - get: git
+  - task: release
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: registry.ops.scalecf.net/genesis-community/concourse
+      inputs:
+      - name: version
+      - name: git
+      outputs:
+      - name: gh
+      - name: pushme
+      - name: notifications
+      run:
+        path: ./git/ci/scripts/shipit
+        args: []
+      params:
+        REPO_ROOT:    git
+        VERSION_FROM: version/number
+        RELEASE_ROOT: gh
+        REPO_OUT:     pushme
+        NOTIFICATION_OUT: notifications
+        BRANCH:         main
+        GITHUB_OWNER:   (( grab meta.github.owner ))
+        GIT_EMAIL:      (( grab meta.git.email ))
+        GIT_NAME:       (( grab meta.git.name ))
+        AWS_ACCESS_KEY: (( grab meta.aws.access ))
+        AWS_SECRET_KEY: (( grab meta.aws.secret ))
+  - put: upload-git
+    resource: git
+    params:
+      rebase: true
+      repository: pushme
+  - put: github-release
+    resource: (( grab meta.name ))
+    params:
+      name:   gh/name
+      tag:    gh/tag
+      body:   gh/notes.md
+      globs: [gh/artifacts/*]
+  # Without this the version resource stays at the version just cut, and
+  # bump: final on an already-final version is a no-op -- so the next run
+  # would cut the same version again. shipit ends the same way.
   - put: version-bump-patch
     resource: version
     params:

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,6 +1,63 @@
+The first release since 0.1.3, and the first that can be bumped without editing
+files by hand. The major version moves to 2 so the scheduler, the CF CLI plugin
+and this BOSH release share one.
 
-# ocf-scheduler
-Bumped  to v1.0.2
+# Upstream artifacts
 
-# ocf-scheduler
-Bumped  to v1.0.3
+* **ocf-scheduler 2.0.2** (was a hand-placed build that never corresponded to any
+  published release) — brings timezone support and the CAPI V3 job fields, and on
+  top of 2.0.1 a dependency refresh carrying the echo fix for GHSA-vfp3-v2gw-7wfq.
+  The scheduler serves no static files, so that advisory never reached it.
+* **ocf-scheduler-cf-plugin 2.0.0** (was 1.0.0) — upstream renamed every asset
+  from `-linux-amd64` to `+linux.amd64`, which the old glob could not match, so
+  this blob had been pinned by breakage rather than by choice. 2.0.0 adds the
+  `--timezone` flag, `cf scheduler-time-zones`, a `--log-rate-limit` flag on
+  `create-job`, and execution-history filtering. Its major bump is version
+  alignment, not a compatibility break: every 1.2.0 command and flag is unchanged.
+
+# arm64
+
+The scheduler package now ships both `linux/amd64` and `linux/arm64` and selects
+between them with `uname -m` at compile time, so one release deploys to either
+stemcell. Groundwork for the ARM64 RFC (cloudfoundry/community#1530).
+
+The vendored `cf-cli-8-linux` and `golang-1.22-linux` packages are unchanged and
+almost certainly amd64-only; the smoke-tests errand depends on both, so smoke
+tests on an arm64 stemcell are not yet supported.
+
+# Packaging
+
+* The upstream version no longer appears in any tracked file. Package specs glob
+  on it and the packaging scripts derive the tarball's inner directory from the
+  matched filename, so a bump touches `config/blobs.yml` and nothing else.
+* `scheduler-cf-plugin` now carries every published platform — linux, darwin and
+  windows — installed under `dist/` alongside the native binary the smoke-tests
+  errand executes. It is also a dependency of the `scheduler` job now, not only
+  of smoke-tests, so the binaries reach the scheduler VM.
+* A new `scheduler-crossbuilds` package carries the darwin scheduler builds. No
+  job references it, so it ships in the release tarball without ever being
+  compiled on a linux stemcell.
+
+# Fixed
+
+* `jobs/smoke-tests` declared `templates: run: bin/run` — the errand convention —
+  but the deployment manifest is where BOSH reads `lifecycle: errand`. The
+  restored testflight manifest declares it there.
+* `manifests/ocf-scheduler.yml` is restored. It had never existed under that
+  name: the only manifest ever committed was `manifests/scheduler.yml`, added in
+  May 2022 and deleted two days later as collateral in an unrelated commit. The
+  pipeline added a year afterwards has looked for the missing filename ever
+  since, so `testflight` could never run.
+
+# Known gaps
+
+`testflight` builds and uploads a release but cannot deploy: the manifest needs a
+Postgres URI and a UAA client that the test environment does not yet provide.
+Deployments through the Genesis kit are unaffected — the kit supplies both.
+
+The bundled plugin 2.0.0 was itself cut by hand rather than by its pipeline, whose
+`test` job cannot authenticate to the test Cloud Foundry. Its artifacts were
+verified with `go build` and `go vet` only; no integration test ran against a live
+scheduler.
+
+This release was cut without a passing `testflight`.


### PR DESCRIPTION
Two commits: a `shipit-manual` job so a final release can be cut at all, and a release-notes correction so that release names the right artifacts.

## 1. Add a shipit-manual job without the rc gate

`shipit` takes `version` and `git` with `passed: [rc]`, and `rc` in turn requires `testflight`. `testflight` cannot pass in this environment — its manifest needs a Postgres URI and a UAA client the test environment does not provide, so it stops at `bosh int --var-errs` on nine unset variables.

The result is that there is currently **no path to a final release at all**. Cutting one locally is not an alternative either: the release has to run where the blobstore credentials resolve, which is Concourse, not a workstation. (Confirmed the hard way today — the AWS key in a local `config/private.yml` was rejected with `InvalidAccessKeyId`, while the same operation succeeded immediately in CI against the Vault-resolved credentials.)

`shipit-manual` is the same plan as `shipit` with the `passed:` constraints removed. Two deliberate differences:

- **`public: false`**, unlike `shipit`. The job's params carry `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` and the git credentials, and every job in this pipeline is world-readable without authentication, so its logs must not be.
- **It keeps `shipit`'s closing `put: version-bump-patch`.** This was missing in the first draft. Without it the version resource stays at the version just cut, and `bump: final` on an already-final version is a no-op — so a second run would cut the *same* version again. Both jobs now end identically.

`./ci/repipe validate` passes.

## 2. Name the shipped blob versions in release notes

The notes described **scheduler 2.0.1** and **plugin 1.2.0**. Today's bump jobs moved the blobs to **2.0.2** and **2.0.0**, and `shipit` publishes `ci/release_notes.md` verbatim as the GitHub release body — so cutting a release would have named the wrong versions of both artifacts.

The entries now also say what changed in each, since the reasons moved along with the numbers: 2.0.2 adds a dependency refresh carrying the echo fix for GHSA-vfp3-v2gw-7wfq (which never reached the scheduler, as it serves no static files), and plugin 2.0.0 adds `--timezone`, `cf scheduler-time-zones`, `--log-rate-limit` on `create-job`, and history filtering. The plugin's major bump is version alignment, not a compatibility break.

Known gaps additionally records that plugin 2.0.0 was cut by hand rather than by its pipeline — verified with `go build` and `go vet` only, with no integration test against a live scheduler.

## Note on the base branch

This targets `main` rather than `develop`. `main` is 4 commits ahead of `develop` and `develop` has nothing unique, because the blob bump jobs `put: git` to whatever the pipeline's git resource tracks — currently `main`. So CI writes to `main` while humans work on `develop`, and `develop` drifts behind after every bump. Worth bringing `develop` back up to `main` after this merges.

## After merging

**Repipe.** The deployed pipeline has no `shipit-manual` yet, and `ci/settings.yml` points the git resource at `main`, so the repipe has to follow the merge. Note `ci/repipe` always pauses the pipeline on exit, so it needs an explicit unpause afterwards.

Testflight remains blocked on the nine `MANIFEST_VARS`; this job routes around that gate rather than fixing it, and the release notes say so.